### PR TITLE
Move ldapclient class to osuosl colo only

### DIFF
--- a/data/colo/osuosl.yaml
+++ b/data/colo/osuosl.yaml
@@ -1,4 +1,6 @@
 ---
+classes:
+  - ldapclient
 
 dnsclient::nameservers:
   - '140.211.166.130'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,7 +11,6 @@ classes:
   - collectd::plugin::interface
   - collectd::plugin::write_http
   - customfact
-  - ldapclient
   - pam
   - puppet_asf
   - ssh_asf # this pulls in both server and client by default

--- a/modules/ldapclient/manifests/install/centos/65.pp
+++ b/modules/ldapclient/manifests/install/centos/65.pp
@@ -26,9 +26,14 @@ class ldapclient::install::centos::65 (
     '/etc/openldap/cacerts':
       ensure  => directory,
       mode    => 755;
-    '/etc/openldap/cacerts/ldap-client.pem':
+    $tlscertpath:
       content  =>  $ldapcert,
       require =>  File['/etc/openldap/cacerts'];
   }
+
+  exec { "/usr/sbin/authconfig --enableldap --enableldapauth --enabletls --ldapbasedn='$nssbasedn' --ldapserver='$ldapservers' --ldaploadcacert=file:///$tlscertpath --update":
+        unless  => "/bin/grep -qr ldap /etc/pam.d",
+        require => File[$tlscertpath],
+      }
 
 }


### PR DESCRIPTION
Currently we're enabling ldap for auth on all our puppet'd hosts,
regardless of whether they can actually talk to our LDAP
servers. That, obviously, is kinda silly. Long-term, we should work up
a way for non-OSUOSL hosts to be able to talk to LDAP, but for now,
moving the ldapclient class inclusion into the osuosl.yaml colo file
gets us the result we need.