### PR TITLE
Add the machinery necessary to run rspec-puppet tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ ssl/
 # Other files and folders
 .settings/
 .project
+*.sw*
+.ruby-*
 
 .bundle
 Gemfile.lock

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--order random --format progress --fail-fast --color

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,9 @@ source "https://rubygems.org"
 gem 'r10k'
 gem 'hiera-eyaml'
 gem 'hiera-eyaml-gpg'
+
+gem 'rspec', '~> 2.99'
+gem 'rspec-puppet'
+gem 'puppet', '~> 3.6.0'
+gem 'puppetlabs_spec_helper', :github => 'jenkins-infra/puppetlabs_spec_helper'
+gem 'serverspec'

--- a/modules/orthrus/manifests/init.pp
+++ b/modules/orthrus/manifests/init.pp
@@ -2,10 +2,10 @@
 
 class orthrus {
 
-  case $asfosname { 
+  case $asfosname {
     ubuntu: {
 
-      package { 'orthrus': 
+      package { 'orthrus':
         ensure  => present,
         require => apt::source['asf_internal'],
       }
@@ -20,7 +20,7 @@ class orthrus {
     }
     centos: {
 
-      package { 'orthrus': 
+      package { 'orthrus':
         ensure  => present,
         require => Yumrepo['asf_internal'],
       }

--- a/modules/orthrus/manifests/init.pp
+++ b/modules/orthrus/manifests/init.pp
@@ -4,36 +4,27 @@ class orthrus {
 
   case $asfosname {
     ubuntu: {
-
-      package { 'orthrus':
-        ensure  => present,
-        require => apt::source['asf_internal'],
-      }
-
-      exec { 'setuid-ortpasswd':
-        command => '/bin/chmod u+s /usr/local/bin/ortpasswd',
-        unless  => '/usr/bin/test -u /usr/local/bin/ortpasswd',
-        onlyif  => '/usr/bin/test -f /usr/local/bin/ortpasswd',
-        require => Package['orthrus'],
-      }
-
+      $repo_resource = Apt::Source['asf_internal']
+      $ortpasswd_path = '/usr/local/bin/ortpasswd'
     }
     centos: {
-
-      package { 'orthrus':
-        ensure  => present,
-        require => Yumrepo['asf_internal'],
-      }
-
-      exec { 'setuid-ortpasswd':
-        command => '/bin/chmod u+s /usr/bin/ortpasswd',
-        unless  => '/usr/bin/test -u /usr/bin/ortpasswd',
-        onlyif  => '/usr/bin/test -f /usr/bin/ortpasswd',
-        require => Package['orthrus'],
-      }
-
+      $repo_resource = Yumrepo['asf_internal']
+      $ortpasswd_path = '/usr/bin/ortpasswd'
     }
     default: {
     }
+  }
+
+  package { 'orthrus':
+    ensure  => present,
+    require => $repo_resource,
+  }
+
+  exec { 'setuid-ortpasswd':
+    command => "chmod u+s ${ortpasswd_path}",
+    unless  => "test -u ${ortpasswd_path}",
+    onlyif  => "test -f ${ortpasswd_path}",
+    path    => ['/bin', '/usr/bin'],
+    require => Package['orthrus'],
   }
 }

--- a/spec/classes/orthrus/orthrus_spec.rb
+++ b/spec/classes/orthrus/orthrus_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'orthrus' do
+  context 'on ubuntu' do
+    let(:facts) do
+      {
+        :asfosname => 'ubuntu',
+      }
+    end
+
+    it { should contain_package('orthrus').with_require('Apt::Source[asf_internal]') }
+  end
+
+  context 'on CentOS' do
+    let(:facts) do
+      {
+        :asfosname => 'centos',
+      }
+    end
+
+    it { should contain_package('orthrus').with_require('Yumrepo[asf_internal]') }
+  end
+end

--- a/spec/classes/orthrus/orthrus_spec.rb
+++ b/spec/classes/orthrus/orthrus_spec.rb
@@ -1,14 +1,21 @@
 require 'spec_helper'
 
 describe 'orthrus' do
+  shared_examples 'an orthrus installation' do
+    it { should contain_package('orthrus').with_require(repo_resource) }
+    it { should contain_exec('setuid-ortpasswd').with_require('Package[orthrus]') }
+  end
+
+
   context 'on ubuntu' do
     let(:facts) do
       {
         :asfosname => 'ubuntu',
       }
     end
+    let(:repo_resource) { 'Apt::Source[asf_internal]' }
 
-    it { should contain_package('orthrus').with_require('Apt::Source[asf_internal]') }
+    it_behaves_like 'an orthrus installation'
   end
 
   context 'on CentOS' do
@@ -17,7 +24,8 @@ describe 'orthrus' do
         :asfosname => 'centos',
       }
     end
+    let(:repo_resource) { 'Yumrepo[asf_internal]' }
 
-    it { should contain_package('orthrus').with_require('Yumrepo[asf_internal]') }
+    it_behaves_like 'an orthrus installation'
   end
 end

--- a/spec/fixtures/site.pp
+++ b/spec/fixtures/site.pp
@@ -1,0 +1,1 @@
+node default { }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+require 'rubygems'
+require 'rspec'
+require 'puppet'
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.mock_with :rspec
+  c.module_path = File.expand_path(File.dirname(__FILE__) + '/../modules')
+  c.manifest = File.expand_path(File.dirname(__FILE__) + '/fixtures/site.pp')
+
+  c.default_facts = {
+    :kernel => 'Linux',
+  }
+
+  c.before(:each) do
+    # Workaround until this is fixed:
+    #   <https://tickets.puppetlabs.com/browse/PUP-1547>
+    require 'puppet/confine/exists'
+    Puppet::Confine::Exists.any_instance.stubs(:which => '')
+  end
+end


### PR DESCRIPTION
This is largely cribbed from jenkins-infra RSpec tooling which can be found in: https://github.com/jenkins-infra/jenkins-infra/spec

For more information about how to use rspec-puppet see: http://rspec-puppet.com/