### PR TITLE
Add Asf999 logging to fail2ban

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -33,8 +33,8 @@ mod 'epel',
 
 
 mod 'fail2ban',
-  :git => 'https://github.com/netmanagers/puppet-fail2ban',
-  :branch => 'master'
+  :git => 'https://github.com/stumped2/puppet-fail2ban',
+  :branch => 'fix_actionsource'
 
 
 mod 'firewall',

--- a/data/nodes/devops.apache.org.yaml
+++ b/data/nodes/devops.apache.org.yaml
@@ -2,3 +2,13 @@
 classes: 
   - rbldnsd::master::setup
   - puppet_asf::master
+
+fail2ban_asf::config::jails:
+  asf999:
+    filter: 'sshd-asf999'
+    action:
+      - 'asf999-log[name=asf999, dest=root@apache.org, sender=fail2ban@apache.org]'
+    logpath: '/var/log/auth.log'
+    maxretry: 1
+    bantime: 2
+    enable: false

--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -79,6 +79,15 @@ fail2ban_asf::config::jails:
     maxretry: 5
     enable: true
 
+  asf999:
+    filter: 'sshd-asf999'
+    action:
+      - 'asf999-log[name=asf999, dest=root@apache.org, sender=fail2ban@apache.org]'
+    logpath: '/var/log/auth.log'
+    maxretry: 1
+    bantime: 2
+    enable: false
+
 ldapclient::install::ubuntu::1404::tlscertpath:  '/etc/ldap/cacerts/ldap-client.pem'
 ldapclient::install::ubuntu::1404::pamhostcheck: 'yes'
 

--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -89,15 +89,6 @@ fail2ban_asf::config::jails:
     maxretry: 5
     enable: true
 
-  asf999:
-    filter: 'sshd-asf999'
-    action:
-      - 'asf999-log[name=asf999, dest=root@apache.org, sender=fail2ban@apache.org]'
-    logpath: '/var/log/auth.log'
-    maxretry: 1
-    bantime: 2
-    enable: false
-
 ldapclient::install::ubuntu::1404::tlscertpath:  '/etc/ldap/cacerts/ldap-client.pem'
 ldapclient::install::ubuntu::1404::pamhostcheck: 'yes'
 

--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -69,6 +69,16 @@ apt::unattended_upgrades::origins:
 
 fail2ban::service_status: true
 
+fail2ban_asf::config::filters:
+  sshd-asf999:
+    filtername: 'sshd-asf999'
+    filtersource: 'puppet:///modules/fail2ban_asf/fail2ban/conf/filter.d/sshd-asf999.conf'
+
+fail2ban_asf::config::actions:
+  asf999-log:
+    actionname: 'asf999-log'
+    actionsource: 'puppet:///modules/fail2ban_asf/fail2ban/conf/action.d/asf999-log.conf'
+
 fail2ban_asf::config::jails:
   ssh:
     filter: sshd

--- a/modules/fail2ban_asf/files/fail2ban/conf/action.d/asf999-log.conf
+++ b/modules/fail2ban_asf/files/fail2ban/conf/action.d/asf999-log.conf
@@ -1,0 +1,59 @@
+# Fail2Ban configuration file
+#
+# Original Author: Cyril Jaquier
+# Adpated by: Geoffrey Corey
+#
+#
+
+[INCLUDES]
+
+before = sendmail-common.conf
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart =
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop =
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = printf %%b "Subject: [Fail2Ban] <name>: The IP <ip> logged in on `uname -n` as asf999
+            Date: `LC_TIME=C date -u +"%%a, %%d %%h %%Y %%T +0000"`
+            From: <sendername> <<sender>>
+            To: <dest>\n
+            Hi,\n
+            The IP <ip> has logged in as asf999.\n
+            Regards,\n
+            Fail2Ban" | /usr/sbin/sendmail -f <sender> <dest>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban =
+
+[Init]
+
+# Default name of the chain
+#
+name = default

--- a/modules/fail2ban_asf/files/fail2ban/conf/filter.d/sshd-asf999.conf
+++ b/modules/fail2ban_asf/files/fail2ban/conf/filter.d/sshd-asf999.conf
@@ -1,0 +1,21 @@
+# Fail2Ban filter for asf999 logins
+#
+
+[INCLUDES]
+
+# Read common prefixes. If any customizations available -- read them from
+# common.local
+before = common.conf
+
+
+[Definition]
+
+_daemon = sshd
+
+failregex = ^%(__prefix_line)sAccepted publickey for asf999 from <HOST> .*$
+
+ignoreregex = 
+
+# DEV Notes:
+#
+#   Aims to detect any valid login by the asf999 user.

--- a/modules/fail2ban_asf/manifests/config.pp
+++ b/modules/fail2ban_asf/manifests/config.pp
@@ -8,5 +8,7 @@ class fail2ban_asf::config (
   create_resources(fail2ban::jail, $jails)
   $filters = hiera_hash('fail2ban_asf::config::filters', {})
   create_resources(fail2ban::filter, $filters)
+  $actions = hiera_hash('fail2ban_asf::config::actions', {})
+  create_resources(fail2ban::action, $actions)
 }
 


### PR DESCRIPTION
@markt-asf requested to add asf999 log in logging.

This adds the email notification that asf999 has logged into a host.