### PR TITLE
change ownership of svn from root to whimsysvn

### DIFF
--- a/modules/whimsy_server/manifests/cronjobs.pp
+++ b/modules/whimsy_server/manifests/cronjobs.pp
@@ -6,8 +6,8 @@ class whimsy_server::cronjobs (
 
   cron { 'svnupdate':
     ensure  => present,
-    command => 'bash -c \'(flock -x 1; for i in /srv/svn/*; do cd $i; echo; echo $i; svn cleanup; svn up; done) > /srv/whimsy/www/logs/svn-update 2>&1\'',
-    user    => root,
+    command => 'bash -c \'(flock -x 1; cd /srv/whimsy; /usr/local/bin/rake svn:update) > www/logs/svn-update 2>&1\'',
+    user    => whimsysvn,
     minute  => '*/10'
   }
 

--- a/modules/whimsy_server/manifests/init.pp
+++ b/modules/whimsy_server/manifests/init.pp
@@ -106,6 +106,8 @@ class whimsy_server (
 
   file { '/srv/svn':
     ensure => 'directory',
+    owner  => whimsysvn,
+    group  => whimsysvn,
   }
 
   ############################################################
@@ -205,6 +207,12 @@ class whimsy_server (
     ensure => file,
     owner  => $apache::user,
     group  => $apache::group,
+  }
+
+  file { '/srv/whimsy/www/logs/svn-update':
+    ensure => file,
+    owner  => whimsysvn,
+    group  => whimsysvn,
   }
 
 }


### PR DESCRIPTION
Puppet will only set the ownership of the directory and log; this
would be sufficient for a new install but at the moment there is
existing content and an existing root cron job doing updates.

I've done:

  chown -R whimsysvn:whimsysvn /srv/svn

... but if the cronjob kicks off before this puppet update is applied,
the whimsysvn cronjob may fail due to lacking permissions on files
created by root