### PR TITLE
Redirects to home.apache.org

### DIFF
--- a/data/nodes/home.apache.org.yaml
+++ b/data/nodes/home.apache.org.yaml
@@ -82,8 +82,6 @@ vhosts_asf::vhosts::vhosts:
     vhost_name: '*'
     port: 80
     servername: 'home.apache.org'
-    serveraliases:
-      - 'people.apache.org'
     default_vhost: true
     docroot: '/var/www/html'
     manage_docroot: false
@@ -104,8 +102,6 @@ vhosts_asf::vhosts::vhosts:
     port: 443
     ssl: true
     servername: 'home.apache.org'
-    serveraliases:
-      - 'people.apache.org'
     serveradmin: 'webmaster@apache.org'
     docroot: '/var/www/html'
     manage_docroot: false
@@ -116,3 +112,32 @@ vhosts_asf::vhosts::vhosts:
       <Directory "/home/*/public_html/">
         Options Indexes MultiViews
       </Directory>
+      
+  # Redirect from old hostnames to home.apache.org, e.g.
+  # http://people.apache.org/anything -> http://home.apache.org/anything
+  # https://people.apache.org/anything -> https://home.apache.org/anything
+  people:
+    vhost_name: '*'
+    port: 80
+    servername: 'people.apache.org'
+    docroot: '/var/www/html'
+    default_vhost: true
+    redirect_status => 'permanent',
+    redirect_dest   => 'http://home.apache.org/'
+    access_log_file: 'people_access.log'
+    error_log_file: 'people_error.log'
+
+  people-ssl:
+    vhost_name: '*'
+    ensure: 'present'
+    port: 443
+    ssl: true
+    default_vhost: true
+    servername: 'people.apache.org'
+    serveradmin: 'webmaster@apache.org'
+    docroot: '/var/www/html'
+    redirect_status => 'permanent',
+    redirect_dest   => 'https://home.apache.org/'
+    access_log_file: 'people-ssl_access.log'
+    error_log_file: 'people-ssl_error.log'  
+  


### PR DESCRIPTION
Strawman (untested) 

HTTP permanent redirect from http://people.apache.org/* to https://home.apache.org/*  -- ensures a single hostname

Note how the "people" vhosts are the `default_vhost` so they redirect for any other hostnames as well. - you may want to change this as it can complicates testing on other hosts.

However this change does not enforce https:// as there (should not be) any sensitive data on home.
