### PR TITLE
replace pull with fetch+reset

### DIFF
--- a/modules/gitwcsub/files/app/gitwcsub.py
+++ b/modules/gitwcsub/files/app/gitwcsub.py
@@ -209,7 +209,9 @@ def updatePending():
             # Otherwise, just pull in changes
                 else:
                     logging.info("Pulling changes into %s" % path)
-                    rv = subprocess.check_output(("git", "pull"))
+                    rv = subprocess.check_output(("git", "fetch", "origin", config.get("Misc", "branch")))
+                    logging.info(rv)
+                    rv = subprocess.check_output(("git", "reset", "--hard", "origin/%s" % config.get("Misc", "branch")))
                     logging.info(rv)
             except Exception as err:
                 logging.error("Git update error: %s" % err)


### PR DESCRIPTION
... because pull barfs when faced with forced pushes; assume the source
is the canonical master and there is no local changes that need to be
retained.