### PR TITLE
move /srv to /x1

### DIFF
--- a/data/nodes/whimsy-vm2.apache.org.yaml
+++ b/data/nodes/whimsy-vm2.apache.org.yaml
@@ -52,13 +52,13 @@ rvm::rvm_gems:
      ensure: latest
 
 whimsy_server::apache_mailmap:
-  secretary: "/usr/local/bin/ruby2.3.0 /srv/whimsy/www/secmail/deliver.rb"
-  members: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/deliver.rb"
-  board: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/deliver.rb"
+  secretary: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/www/secmail/deliver.rb"
+  members: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/deliver.rb"
+  board: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/deliver.rb"
 
 whimsy_server::whimsysvn_mailmap:
-  svnupdate: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/svnupdate.rb"
-  gitupdate: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/gitupdate.rb"
+  svnupdate: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/svnupdate.rb"
+  gitupdate: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/gitupdate.rb"
 
 whimsy_server::apmail_keycontent: |
   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCGgAIeu+84ADF0TjKLPJaEE8747Xb+KNjh8ESujparlJcoD0EaYXZ7fF7X24Di5DzETLnv3XzLRuTUG3RzfAovrrgdIOqF23L5QMK3yNHgphNF3ri3ClwATscursH7B38QpEqTTsFGYsBwpJImKEqCkVdoLf5AVu6zhoJIsvW+mDzwvjJN/II/iFeR2/gSm73TWif0tkL7ZSspl2Dj4YNcngCL/nPmPK9tA6EJO3FcZSJzji3pfMIReBM8E0123rYF1EaNqjqF9mw3gf4jNTi9eob3l7Pchdi/onDzthpJpjw6eDcyUisYpotAO1LR0+CJpwfbxSVsjMayKUEPuop apmail@hermes.apache.org
@@ -78,7 +78,7 @@ vhosts_whimsy::vhosts::vhosts:
     serveraliases:
     -  'whimsy-test.apache.org'
     port: 80
-    docroot: '/srv/whimsy/www'
+    docroot: '/x1/srv/whimsy/www'
     error_log_file: 'whimsy_error.log'
     access_log_file: 'whimsy_access.log'
     options:
@@ -146,22 +146,22 @@ vhosts_whimsy::vhosts::vhosts:
 
       AddCharset UTF-8 .json
 
-      <Directory /srv/whimsy/www/>
+      <Directory /x1/srv/whimsy/www/>
         AddHandler cgi-script .cgi
         MultiViewsMatch Any
         CheckSpelling On
       </Directory>
 
-      <Directory /srv/whimsy/www/public/>
+      <Directory /x1/srv/whimsy/www/public/>
         Header add Access-Control-Allow-Origin "*"
         Options +Indexes
       </Directory>
 
-      <Directory /srv/whimsy/www/logs>
+      <Directory /x1/srv/whimsy/www/logs>
         Options +Indexes
       </Directory>
 
-      <Directory /srv/whimsy/www/members/log>
+      <Directory /x1/srv/whimsy/www/members/log>
         Options +Indexes
       </Directory>
 
@@ -169,7 +169,7 @@ vhosts_whimsy::vhosts::vhosts:
       RewriteRule ^.*$ - [E=HTTP_AUTHORIZATION:%%{}{HTTP:Authorization}]
 
       # for secretary workbench
-      Alias /members/received /srv/secretary/workbench/documents/received
+      Alias /members/received /x1/srv/secretary/workbench/documents/received
 
       RedirectMatch ^/classic/roster/committee$ https://whimsy.apache.org/classic/roster/committee/
       RedirectMatch ^/classic/roster/committer$ https://whimsy.apache.org/classic/roster/committer/

--- a/data/nodes/whimsy-vm3.apache.org.yaml
+++ b/data/nodes/whimsy-vm3.apache.org.yaml
@@ -52,13 +52,13 @@ rvm::rvm_gems:
      ensure: latest
 
 whimsy_server::apache_mailmap:
-  secretary: "/usr/local/bin/ruby2.3.0 /srv/whimsy/www/secmail/deliver.rb"
-  members: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/deliver.rb"
-  board: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/deliver.rb"
+  secretary: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/www/secmail/deliver.rb"
+  members: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/deliver.rb"
+  board: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/deliver.rb"
 
 whimsy_server::whimsysvn_mailmap:
-  svnupdate: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/svnupdate.rb"
-  gitupdate: "/usr/local/bin/ruby2.3.0 /srv/whimsy/tools/gitupdate.rb"
+  svnupdate: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/svnupdate.rb"
+  gitupdate: "/usr/local/bin/ruby2.3.0 /x1/srv/whimsy/tools/gitupdate.rb"
 
 whimsy_server::apmail_keycontent: |
   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDCGgAIeu+84ADF0TjKLPJaEE8747Xb+KNjh8ESujparlJcoD0EaYXZ7fF7X24Di5DzETLnv3XzLRuTUG3RzfAovrrgdIOqF23L5QMK3yNHgphNF3ri3ClwATscursH7B38QpEqTTsFGYsBwpJImKEqCkVdoLf5AVu6zhoJIsvW+mDzwvjJN/II/iFeR2/gSm73TWif0tkL7ZSspl2Dj4YNcngCL/nPmPK9tA6EJO3FcZSJzji3pfMIReBM8E0123rYF1EaNqjqF9mw3gf4jNTi9eob3l7Pchdi/onDzthpJpjw6eDcyUisYpotAO1LR0+CJpwfbxSVsjMayKUEPuop apmail@hermes.apache.org
@@ -79,7 +79,7 @@ vhosts_whimsy::vhosts::vhosts:
       -  'whimsy-test.apache.org'
       -  'whimsy3.apache.org'
     port: 80
-    docroot: '/srv/whimsy/www'
+    docroot: '/x1/srv/whimsy/www'
     error_log_file: 'whimsy_error.log'
     access_log_file: 'whimsy_access.log'
     options:
@@ -147,22 +147,22 @@ vhosts_whimsy::vhosts::vhosts:
 
       AddCharset UTF-8 .json
 
-      <Directory /srv/whimsy/www/>
+      <Directory /x1/srv/whimsy/www/>
         AddHandler cgi-script .cgi
         MultiViewsMatch Any
         CheckSpelling On
       </Directory>
 
-      <Directory /srv/whimsy/www/public/>
+      <Directory /x1/srv/whimsy/www/public/>
         Header add Access-Control-Allow-Origin "*"
         Options +Indexes
       </Directory>
 
-      <Directory /srv/whimsy/www/logs>
+      <Directory /x1/srv/whimsy/www/logs>
         Options +Indexes
       </Directory>
 
-      <Directory /srv/whimsy/www/members/log>
+      <Directory /x1/srv/whimsy/www/members/log>
         Options +Indexes
       </Directory>
 
@@ -170,7 +170,7 @@ vhosts_whimsy::vhosts::vhosts:
       RewriteRule ^.*$ - [E=HTTP_AUTHORIZATION:%%{}{HTTP:Authorization}]
 
       # for secretary workbench
-      Alias /members/received /srv/secretary/workbench/documents/received
+      Alias /members/received /x1/srv/secretary/workbench/documents/received
 
       RedirectMatch ^/classic/roster/committee$ https://whimsy.apache.org/classic/roster/committee/
       RedirectMatch ^/classic/roster/committer$ https://whimsy.apache.org/classic/roster/committer/

--- a/modules/whimsy_server/manifests/init.pp
+++ b/modules/whimsy_server/manifests/init.pp
@@ -9,6 +9,11 @@ class whimsy_server (
 
 ) {
 
+  file { '/srv':
+    ensure => link,
+    target => '/x1/srv'
+  }
+
   ############################################################
   #                       System Packages                    #
   ############################################################
@@ -55,7 +60,7 @@ class whimsy_server (
     spawnmethod        => 'smart-lv2',
   } ->
 
-  vcsrepo { '/srv/whimsy':
+  vcsrepo { '/x1/srv/whimsy':
     ensure   => latest,
     provider => git,
     source   => 'https://git-dual.apache.org/repos/asf/whimsy.git',
@@ -64,7 +69,7 @@ class whimsy_server (
 
   exec { 'rake::update':
     command     => '/usr/local/bin/rake update',
-    cwd         => '/srv/whimsy',
+    cwd         => '/x1/srv/whimsy',
     refreshonly => true
   }
 
@@ -104,13 +109,13 @@ class whimsy_server (
     group  => whimsysvn,
   }
 
-  file { '/srv/svn':
+  file { '/x1/srv/svn':
     ensure => 'directory',
     owner  => whimsysvn,
     group  => whimsysvn,
   }
 
-  file { '/srv/git':
+  file { '/x1/srv/git':
     ensure => 'directory',
     owner  => whimsysvn,
     group  => whimsysvn,
@@ -120,26 +125,26 @@ class whimsy_server (
   #             Other Working Directories and Files          #
   ############################################################
 
-  file { '/srv/gpg':
+  file { '/x1/srv/gpg':
     ensure => directory,
     owner  => $apache::user,
     group  => $apache::group,
     mode   => '0700',
   }
 
-  file { '/srv/subscriptions':
+  file { '/x1/srv/subscriptions':
     ensure => directory,
     owner  => 'apmail',
     group  => 'apmail',
   }
 
   $directories = [
-    '/srv/agenda',
-    '/srv/secretary',
-    '/srv/secretary/tlpreq',
-    '/srv/whimsy/www/board/minutes',
-    '/srv/whimsy/www/logs',
-    '/srv/whimsy/www/public',
+    '/x1/srv/agenda',
+    '/x1/srv/secretary',
+    '/x1/srv/secretary/tlpreq',
+    '/x1/srv/whimsy/www/board/minutes',
+    '/x1/srv/whimsy/www/logs',
+    '/x1/srv/whimsy/www/public',
   ]
 
   file { $directories:
@@ -148,7 +153,7 @@ class whimsy_server (
     group  => $apache::group,
   }
 
-  file { '/srv/whimsy/www/members/log':
+  file { '/x1/srv/whimsy/www/members/log':
     ensure => link,
     target => '/var/log/apache2'
   }
@@ -158,19 +163,19 @@ class whimsy_server (
     mode   => '0755',
   }
 
-  file { '/srv/whimsy/www/status/status.json':
+  file { '/x1/srv/whimsy/www/status/status.json':
     ensure => file,
     owner  => $apache::user,
     group  => $apache::group,
   }
 
-  file { '/srv/whimsy/www/logs/svn-update':
+  file { '/x1/srv/whimsy/www/logs/svn-update':
     ensure => file,
     owner  => whimsysvn,
     group  => whimsysvn,
   }
 
-  file { '/srv/whimsy/www/logs/git-pull':
+  file { '/x1/srv/whimsy/www/logs/git-pull':
     ensure => file,
     owner  => whimsysvn,
     group  => whimsysvn,

--- a/modules/whimsy_server/manifests/procmail.pp
+++ b/modules/whimsy_server/manifests/procmail.pp
@@ -18,7 +18,7 @@ class whimsy_server::procmail (
     mode    => '0640',
   }
 
-  file { '/srv/mbox':
+  file { '/x1/srv/mbox':
     ensure => directory,
     owner  => apmail,
     group  => apmail,
@@ -56,16 +56,16 @@ class whimsy_server::procmail (
     content => template('whimsy_server/apache-mailrc.erb')
   }
 
-  file { '/srv/mail':
+  file { '/x1/srv/mail':
     ensure => directory,
     owner  => $apache::user,
     group  => $apache::group,
   }
 
   $mailboxes = [
-    '/srv/mail/secretary',
-    '/srv/mail/members',
-    '/srv/mail/board'
+    '/x1/srv/mail/secretary',
+    '/x1/srv/mail/members',
+    '/x1/srv/mail/board'
   ]
 
   file { $mailboxes:
@@ -74,14 +74,14 @@ class whimsy_server::procmail (
     group  => $apache::group,
   }
 
-  file { '/srv/mail/procmail.log':
+  file { '/x1/srv/mail/procmail.log':
     ensure => present,
     owner  => $apache::user,
     group  => $apache::group,
   }
 
   logrotate::rule { 'procmail':
-    path         => '/srv/mail/procmail.log',
+    path         => '/x1/srv/mail/procmail.log',
     rotate       => 6,
     rotate_every => 'month',
     missingok    => true,
@@ -108,14 +108,14 @@ class whimsy_server::procmail (
   }
 
 
-  file { '/srv/svn/procmail.log':
+  file { '/x1/srv/svn/procmail.log':
     ensure => present,
     owner  => whimsysvn,
     group  => whimsysvn,
   }
 
   logrotate::rule { 'procmail-svn':
-    path         => '/srv/svn/procmail.log',
+    path         => '/x1/srv/svn/procmail.log',
     rotate       => 6,
     rotate_every => 'month',
     missingok    => true,


### PR DESCRIPTION
Tested with puppet kitchen

Change has already been made to the directory structure on both whimsy-vm2 and
whimsy-vm3:

root@whimsy-vm2:~# ls -l /srv /x1/srv
lrwxrwxrwx  1 root root    7 May  9 14:50 /srv -> /x1/srv

/x1/srv:
total 36
drwxr-xr-x  2 www-data  www-data  4096 May  1 12:57 agenda
drwxr-xr-x  3 whimsysvn whimsysvn 4096 Mar  9 17:30 git
drwx------  2 www-data  www-data  4096 May  7 23:03 gpg
drwxr-xr-x  5 www-data  www-data  4096 May  1 06:34 mail
drwxr-xr-x  3 apmail    apmail    4096 Jan  8 19:33 mbox
drwxr-xr-x  4 www-data  www-data  4096 Mar 17 16:04 secretary
drwxr-xr-x  2 apmail    apmail    4096 Mar 16 04:11 subscriptions
drwxr-xr-x 23 whimsysvn whimsysvn 4096 May  1 06:34 svn
drwxr-xr-x  9 root      root      4096 May  5 13:47 whimsy

root@whimsy-vm3:~# ls -l /srv /x1/srv
lrwxrwxrwx  1 root root    7 May  9 14:53 /srv -> /x1/srv

/x1/srv:
total 36
drwxr-xr-x 2 www-data  www-data  4096 Apr 22 20:09 agenda
drwxr-xr-x 3 whimsysvn whimsysvn 4096 Apr 22 20:30 git
drwx------ 2 www-data  www-data  4096 Apr 22 20:08 gpg
drwxr-xr-x 5 www-data  www-data  4096 May  1 06:31 mail
drwxr-xr-x 2 apmail    apmail    4096 Apr 22 20:09 mbox
drwxr-xr-x 3 www-data  www-data  4096 Apr 22 20:09 secretary
drwxr-xr-x 2 apmail    apmail    4096 Apr 22 20:09 subscriptions
drwxr-xr-x 9 whimsysvn whimsysvn 4096 May  1 06:31 svn
drwxr-xr-x 9 root      root      4096 May  5 13:42 whimsy