### PR TITLE
Add Apache Quarks(incubating) committers

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -358,7 +358,7 @@ portals-pmc={reuse:pit-authorization:portals-pmc}
 # provisionr=rvs,tomwhite,mnour,asavu,esammer,ieugen,ak,cimi
 qpid={ldap:cn=qpid,ou=groups,dc=apache,dc=org}
 qpid-pmc={reuse:pit-authorization:qpid-pmc}
-quarks=cazen,djd,dlaboss,home4slc,vdogaru,wcmarsha
+quarks=cazen,djd,dlaboss,home4slc,kathyssaunders,queeniema,vdogaru,wcmarsha
 ranger=alok,bosco,ddas,dillidorai,gates,humbedooh,jghoman,kminder,lmccay,omalley,rmani,sneethir,sradia
 rave={ldap:cn=rave,ou=groups,dc=apache,dc=org}
 rave-pmc={reuse:pit-authorization:rave-pmc}


### PR DESCRIPTION
Good Day!
Could I kindly ask review this PR?
We recently add new committer and It just for http://people.apache.org/phonebook.html?podling=quarks

(I tried to add this via git1-us-west.apache.org but it failed. I could do this 1 month ago but not now.
So I create PR with github. Please tell me if this is not standard solution)

[hadoop@ip-10-0-0-126 infrastructure-puppet]$  git push origin quarks
Username for 'https://git1-us-west.apache.org': cazen
Password for 'https://cazen@git1-us-west.apache.org': 
Counting objects: 7, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 578 bytes | 0 bytes/s, done.
Total 7 (delta 6), reused 0 (delta 0)
remote: You are not authorized to edit this repository.
remote: 
remote: auth check failed
To https://git1-us-west.apache.org/repos/asf/infrastructure-puppet.git
 ! [remote rejected] quarks -> quarks (pre-receive hook declined)
error: failed to push some refs to 'https://git1-us-west.apache.org/repos/asf/infrastructure-puppet.git'