### PR TITLE
comdev bootstrap

### DIFF
--- a/data/nodes/comdev-vm.apache.org.yaml
+++ b/data/nodes/comdev-vm.apache.org.yaml
@@ -30,6 +30,7 @@ apache::mod::event::threadsperchild: '50'
 
 
 base::basepackages:
+  - mod-lua-asf
   - 'lua5.2'
   - 'liblua5.2-dev'
   - 'lua5.2-cjson'

--- a/data/nodes/comdev-vm.apache.org.yaml
+++ b/data/nodes/comdev-vm.apache.org.yaml
@@ -4,7 +4,6 @@ classes:
   - apache::mod::headers
   - apache::mod::authnz_ldap
   - default_pvm_asf
-  - docker
   - elasticsearch
   - loggy
   - ssl::name::wildcard_apache_org


### PR DESCRIPTION
I'm taking a look at https://issues.apache.org/jira/browse/COMDEV-201; but before I do I'm trying to build the vm on my own for testing purposes.  I came across two issues.  For the docker one, I don't see how the current definition could build at all; for the mod-lua one I can only presume that this was initially installed outside of puppet.