### PR TITLE
Add Toree podling to asf-authorization-template

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -446,6 +446,7 @@ tomee={ldap:cn=tomee,ou=groups,dc=apache,dc=org}
 tomee-pmc={reuse:pit-authorization:tomee-pmc}
 tomcat={ldap:cn=tomcat,ou=groups,dc=apache,dc=org}
 tomcat-pmc={reuse:pit-authorization:tomcat-pmc}
+toree=cstubbs,hitesh,jodersky,julien,lbustelo,lresende,rxin,chipsenkbeil
 trafficserver={ldap:cn=trafficserver,ou=groups,dc=apache,dc=org}
 trafficserver-pmc={reuse:pit-authorization:trafficserver-pmc}
 # trafficserver=akundu,andrewhsu,balajd,bcall,dianes,dima,ericb,georgep,jim,jplevyak,manjesh,mlibbey,mturk,pquerna,rayray,sjiang,vmamidi,zwoop


### PR DESCRIPTION
Add Toree Podling committers to asf-authorization-template to enable publishing Toree website that is using svn-pub-sub.