### PR TITLE
Enable write access to Toree podling group

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -1124,6 +1124,9 @@ ea = rw
 [/tinkerpop]
 @tinkerpop = rw
 
+[/incubator/toree]
+@toree = rw
+
 [/incubator/triplesoup]
 * = r
 


### PR DESCRIPTION
After creating the Toree podling group, there is still a need to provide the access level to the group.