### PR TITLE
rough in apache + postfix

### DIFF
--- a/data/nodes/ghmon-vm.apache.org.yaml
+++ b/data/nodes/ghmon-vm.apache.org.yaml
@@ -1,0 +1,71 @@
+---
+classes:
+  - apache
+  - apache::mod::authnz_ldap
+  - apache::mod::headers
+  - apache::mod::proxy
+  - apache::mod::rewrite
+  - vhosts_asf::vhosts
+
+apache::keepalive: 'On'
+apache::keepalive_timeout: '15'
+apache::timeout: 600
+apache::mpm_module: 'event'
+apache::mod::event::listenbacklog: '511'
+apache::mod::event::maxclients: '500'
+apache::mod::event::maxconnectionsperchild: '200000'
+apache::mod::event::maxrequestworkers: '500'
+apache::mod::event::maxsparethreads: '250'
+apache::mod::event::minsparethreads: '150'
+apache::mod::event::serverlimit: '10'
+apache::mod::event::startservers: '5'
+apache::mod::event::threadlimit: '500'
+apache::mod::event::threadsperchild: '50'
+apache::default_vhost: false
+
+postfix::server::relayhost: '[mail-relay.apache.org]:587'
+postfix::server::smtp_use_tls: true
+
+postfix::server::inet_interfaces: 'all'
+postfix::server::mailbox_command: '/usr/bin/procmail -a "$EXTENSION"'
+
+postfix::server::smtpd_tls_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
+postfix::server::smtpd_tls_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+
+logrotate::rule:
+  apache2:
+    ensure: 'present'
+
+vhosts_asf::vhosts::vhosts:
+  ghmon-vm-80:
+    vhost_name: '*'
+    priority: '12'
+    servername: 'ghmon.apache.org'
+    serveraliases:
+      -  'ghmon-vm.apache.org'
+    port: 80
+    ssl: false
+    docroot: '/var/www/html'
+    error_log_file: 'ghmon_error.log'
+#   custom_fragment: |
+#     RedirectMatch permanent ^/(.*)$ https://ghmon.apache.org/$1
+
+  ghmon-vm-443:
+    vhost_name: '*'
+    default_vhost: true
+    servername: 'ghmon.apache.org'
+    serveraliases:
+      -  'ghmon.apache.org'
+    port: 443
+    docroot: '/var/www/html'
+    error_log_file: 'ghmon_error.log'
+    access_log_file: 'ghmon_access.log'
+    options:
+      - '+FollowSymLinks'
+      - '+MultiViews'
+      - '+ExecCGI'
+#   ssl: true
+#   ssl_cert: /etc/letsencrypt/live/ghmon.apache.org/cert.pem
+#   ssl_key: /etc/letsencrypt/live/ghmon.apache.org/privkey.pem
+#   ssl_chain: /etc/letsencrypt/live/ghmon.apache.org/chain.pem
+


### PR DESCRIPTION
next step is letsencrypt/certbot and verifying the ability to send mail

Related svn commit 993135 to dns/zones.   sudo rndc reload requested as
it will be needed before letsencrypt deployment can proceed.