### PR TITLE
rough in group self service proposal

### DIFF
--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -223,10 +223,11 @@ access to dn.subtree="ou=people,dc=apache,dc=org"
 
 ## Allow PMC chairs, and Hudson admins to grant job admin privs
 access to dn.subtree="ou=hudson,ou=apps,ou=groups,dc=apache,dc=org"
-  attrs=memberUid,member
+  attrs=memberUid,member,owner
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by group.exact="cn=pmc-chairs,ou=groups,ou=services,dc=apache,dc=org" write
   by group.exact="cn=hudson-admin,ou=groups,ou=services,dc=apache,dc=org" write
+  by dnattr=owner write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
   by * read
@@ -242,12 +243,25 @@ access to dn.subtree="ou=groups,dc=apache,dc=org"
   by * read
   by anonymous auth
 
-## Allow the PMC chairs to edit group memberships.
-access to dn.subtree="ou=groups,dc=apache,dc=org"
+## Allow members of auth groups to edit their own groups.
+access to dn.subtree="ou=auth,ou=groups,dc=apache,dc=org"
   attrs=memberUid,member
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
+  by dnattr=member write
+  by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by * read
+  by anonymous auth
+
+
+## Allow the PMC chairs and PMC members to edit group memberships.
+access to dn.subtree="ou=groups,dc=apache,dc=org"
+  attrs=memberUid,member,owner
+  by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
+  by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
   by group.exact="cn=pmc-chairs,ou=groups,ou=services,dc=apache,dc=org" write
+  by dnattr=owner write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
   by * read

--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -158,7 +158,7 @@ db={ldap:cn=db,ou=groups,dc=apache,dc=org}
 db-ddlutils=arminw,brianm,brj,henning,mattbaird,mkalen,mvdb,rsfeir,seade,tfischer,thma,tomdz
 db-site={ldap:cn=db-site,ou=groups,dc=apache,dc=org}
 db-torque=brekke,dlr,dobbs,fedor,gmonroe,henning,hhernandez,jmcnally,jon,jtaylor,jvanzyl,kschrader,quintonm,seade,stephenh,tfischer,tv
-db-jdo=brazil,brianm,btopping,clr,dain,ebengston,geirm,madams,mbo,mcaisse,mzaun,pcl,andyj,tilmannz
+db-jdo={ldap:cn=db-jdo,ou=auth,ou=groups,dc=apache,dc=org}
 db-pmc={reuse:pit-authorization:db-pmc}
 deltacloud={ldap:cn=deltacloud,ou=groups,dc=apache,dc=org}
 deltacloud-pmc={reuse:pit-authorization:deltacloud-pmc}

--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -158,7 +158,7 @@ db={ldap:cn=db,ou=groups,dc=apache,dc=org}
 db-ddlutils=arminw,brianm,brj,henning,mattbaird,mkalen,mvdb,rsfeir,seade,tfischer,thma,tomdz
 db-site={ldap:cn=db-site,ou=groups,dc=apache,dc=org}
 db-torque=brekke,dlr,dobbs,fedor,gmonroe,henning,hhernandez,jmcnally,jon,jtaylor,jvanzyl,kschrader,quintonm,seade,stephenh,tfischer,tv
-db-jdo={ldap:cn=db-jdo,ou=auth,ou=groups,dc=apache,dc=org}
+db-jdo=brazil,brianm,btopping,clr,dain,ebengston,geirm,madams,mbo,mcaisse,mzaun,pcl,andyj,tilmannz
 db-pmc={reuse:pit-authorization:db-pmc}
 deltacloud={ldap:cn=deltacloud,ou=groups,dc=apache,dc=org}
 deltacloud-pmc={reuse:pit-authorization:deltacloud-pmc}


### PR DESCRIPTION
See the following thread for background:

https://lists.apache.org/list.html?infrastructure@apache.org:lte=1M:make%20groups%20self%20service

Details:

1) add owner to list of hudson apps attrs, and grant owners write access to
   hudson apps.  (leaving hudson-admin and pmc-chairs in place for now).

2) add ou=auth permissions, modelled after parent (ou=groups) with the following
   changes: members of the group have write permissions, and pmc-chairs
   are not listed.

3) add owner to list of ou=groups attributes, and grand owners write access
   to groups.  (leaving pmc-chairs in place for now).

4) change db-jdo definition in asf-authorization from an inline list to
   a reference to LDAP.