### PR TITLE
convert %(...) => %{...} in vhost custom_fragments

### DIFF
--- a/modules/vhosts_whimsy/README.md
+++ b/modules/vhosts_whimsy/README.md
@@ -78,6 +78,11 @@ module](https://forge.puppetlabs.com/puppetlabs/apache#custom_fragment-1).
             - /board/agenda/
             - /board/publish_minutes
 
+Additionally as the `hiera` and Apache escape sequence for variables uses the
+same syntax, and as the workarounds for escaping in hiera are both clumsy and
+don't consistently work in all environments, this function will globally
+replace %(varname) with %{varname} in vhost `custom_fragment`s.
+
 Sample output
 =============
 

--- a/modules/vhosts_whimsy/lib/puppet/parser/functions/preprocess_vhosts.rb
+++ b/modules/vhosts_whimsy/lib/puppet/parser/functions/preprocess_vhosts.rb
@@ -92,7 +92,8 @@ module Puppet::Parser::Functions
 
     # produce result
     def result
-      @fragment.gsub! /\A\n+/, '' # eliminate leading whitespace
+      @fragment.gsub!(/\A\n+/, '') # eliminate leading whitespace
+      @fragment.gsub!(/%\((\w+:?\w*)\)/, '%{\1}') # convert %(...) => %{...}
       @facts['custom_fragment'] = @fragment unless @fragment.empty?
       @facts
     end


### PR DESCRIPTION
Background: hiera and Apache unfortunately have the same escape sequence for
interpolating variables in strings.  While there are various workarounds for
escaping the escape sequence (%%{}{var} and %{literal('%'}}{var} are both
popular), neither are working for me when trying to do <If> statements.

After more than an hour of trying various alternatives, it seems best to
avoid the syntax clash altogether.  As this change will need to be deployed
and the puppet master restarted before it can be used, I'm pushing it
separately.