### PR TITLE
Convert auth for db-jdo to use LDAP

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -158,7 +158,7 @@ db={ldap:cn=db,ou=groups,dc=apache,dc=org}
 db-ddlutils=arminw,brianm,brj,henning,mattbaird,mkalen,mvdb,rsfeir,seade,tfischer,thma,tomdz
 db-site={ldap:cn=db-site,ou=groups,dc=apache,dc=org}
 db-torque=brekke,dlr,dobbs,fedor,gmonroe,henning,hhernandez,jmcnally,jon,jtaylor,jvanzyl,kschrader,quintonm,seade,stephenh,tfischer,tv
-db-jdo=brazil,brianm,btopping,clr,dain,ebengston,geirm,madams,mbo,mcaisse,mzaun,pcl,andyj,tilmannz
+db-jdo={ldap:cn=db-jdo,ou=auth,ou=groups,dc=apache,dc=org} 
 db-pmc={reuse:pit-authorization:db-pmc}
 deltacloud={ldap:cn=deltacloud,ou=groups,dc=apache,dc=org}
 deltacloud-pmc={reuse:pit-authorization:deltacloud-pmc}


### PR DESCRIPTION
Current data in LDAP:

$ ldapsearch -x -LLL cn=db-jdo -b ou=auth,ou=groups,dc=apache,dc=org member
dn: cn=db-jdo,ou=auth,ou=groups,dc=apache,dc=org
member: uid=brazil,ou=people,dc=apache,dc=org
member: uid=brianm,ou=people,dc=apache,dc=org
member: uid=btopping,ou=people,dc=apache,dc=org
member: uid=clr,ou=people,dc=apache,dc=org
member: uid=dain,ou=people,dc=apache,dc=org
member: uid=ebengston,ou=people,dc=apache,dc=org
member: uid=geirm,ou=people,dc=apache,dc=org
member: uid=madams,ou=people,dc=apache,dc=org
member: uid=mbo,ou=people,dc=apache,dc=org
member: uid=mcaisse,ou=people,dc=apache,dc=org
member: uid=mzaun,ou=people,dc=apache,dc=org
member: uid=pcl,ou=people,dc=apache,dc=org
member: uid=andyj,ou=people,dc=apache,dc=org
member: uid=tilmannz,ou=people,dc=apache,dc=org