### PR TITLE
convert derby auth list to db-derby auth group

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -165,7 +165,7 @@ deltacloud-pmc={reuse:pit-authorization:deltacloud-pmc}
 deltaspike={ldap:cn=deltaspike,ou=groups,dc=apache,dc=org}
 deltaspike-pmc={reuse:pit-authorization:deltaspike-pmc}
 # depot=nicolaken,ajack,anou_mana,mmay,nickchalko
-derby=abrown,andreask,bakksjo,bandaram,bernt,bpendleton,chaase3,dag,davidvc,djd,dyre,fernanda,fuzzylogic,johnemb,halleypo,jboynes,jorgenlo,jta,kahatlen,kmarsden,kristwaa,mamta,mikem,myrnavl,ole,oysteing,rhillegas,scotsmatrix,suresht,thomanie,tmnk,vnarayanan
+db-derby={ldap:cn=db-derby,ou=auth,ou=groups,dc=apache,dc=org} 
 devicemap={ldap:cn=devicemap,ou=groups,dc=apache,dc=org}
 devicemap-pmc={reuse:pit-authorization:devicemap-pmc}
 #directmemory=antelder,bperroud,grobmeier,iocanel,mcucchiara,olamy,raffaeleguidi,simoneg,simonetripodi,sylvain,tommaso,twilliams
@@ -795,7 +795,7 @@ ea = rw
 @db-ddlutils = rw
 
 [/db/derby]
-@derby = rw
+@db-derby = rw
 
 [/db/jdo]
 @db = rw

--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -97,7 +97,6 @@ deltacloud-pmc={ldap:cn=deltacloud,ou=pmc,ou=committees,ou=groups,dc=apache,dc=o
 deltaspike={reuse:asf-authorization:deltaspike}
 deltaspike-pmc={ldap:cn=deltaspike,ou=pmc,ou=committees,ou=groups,dc=apache,dc=org}
 # depot={reuse:asf-authorization:# depot}
-derby={reuse:asf-authorization:derby}
 devicemap={reuse:asf-authorization:devicemap}
 devicemap-pmc={ldap:cn=devicemap,ou=pmc,ou=committees,ou=groups,dc=apache,dc=org}
 directory={reuse:asf-authorization:directory}


### PR DESCRIPTION
Convert derby to use LDAP auth group: cn=db-derby,ou=auth,ou=groups,dc=apache,dc=org

You can verify that the auth group is set up using either of the following:

* `ldapsearch -x cn=db-derby`
* https://whimsy.apache.org/roster/group/db-derby