### PR TITLE
Use a generic name for the current release branch

### DIFF
--- a/modules/buildbot_asf/files/create-ooo-snapshots-index.sh
+++ b/modules/buildbot_asf/files/create-ooo-snapshots-index.sh
@@ -14,7 +14,7 @@ echo '<div id="contenta">
 
   <h2>Build Analysis</h2>
     <p  id="rat"> <a href="https://ci.apache.org/projects/openoffice/rat-output.html" target="_blank">RAT Report</a> on the trunk build.</p>
-    <p  id="rat"> <a href="https://ci.apache.org/projects/openoffice/AOO413/rat-output.html" target="_blank">RAT Report</a> on the AOO413 branch build.</p>
+    <p  id="rat"> <a href="https://ci.apache.org/projects/openoffice/release_branch/rat-output.html" target="_blank">RAT Report</a> on the build based on the current release branch.</p>
   <hr />
 
   <h2>Install Packages / Buildbot Logs</h2>


### PR DESCRIPTION
Using a generic name instead of the actual release branch name (AOO413, AOO414, etc.) there is no need to update this file for every new release.