### PR TITLE
INFRA-12291 change relay host to the one configured in #140

### DIFF
--- a/data/nodes/vmgump-vm3.apache.org.yaml
+++ b/data/nodes/vmgump-vm3.apache.org.yaml
@@ -10,7 +10,7 @@ default_pvm_asf::required_packages:
   - unzip
   - joe
 
-postfix::server::relayhost: '[mail-relay.apache.org]:587'
+postfix::server::relayhost: '[mailrelay1-us-west.apache.org]:587'
 postfix::server::smtp_use_tls: true
 
 postfix::server::inet_interfaces: 'all'


### PR DESCRIPTION
Sending email from vmgump still doesn't work, likely because it is not using the relay that has been configured to allow access with #140 
