### PR TITLE
Clarify the LDAP membership requirement

### DIFF
--- a/data/nodes/proxy1-us-west.apache.org.yaml
+++ b/data/nodes/proxy1-us-west.apache.org.yaml
@@ -755,7 +755,7 @@ vhosts_asf::vhosts::vhosts:
       <Location />
         AuthLDAPUrl "ldaps://ldap2-us-west.apache.org ldap-lb-us.apache.org/ou=people,dc=apache,dc=org?uid"
         AuthLDAPRemoteUserAttribute uid
-        AuthName "PMC Members Only"
+        AuthName "ASF Committers"
         AuthType Basic
         AuthBasicProvider ldap
         Require valid-user

--- a/data/nodes/proxy2-lw-us.apache.org.yaml
+++ b/data/nodes/proxy2-lw-us.apache.org.yaml
@@ -836,7 +836,7 @@ vhosts_asf::vhosts::vhosts:
       <Location />
         AuthLDAPUrl "ldaps://ldap2-us-west.apache.org ldap-lb-us.apache.org/ou=people,dc=apache,dc=org?uid"
         AuthLDAPRemoteUserAttribute uid
-        AuthName "PMC Members Only"
+        AuthName "ASF Committers"
         AuthType Basic
         AuthBasicProvider ldap
         Require valid-user

--- a/data/nodes/proxy2-us-west.apache.org.yaml
+++ b/data/nodes/proxy2-us-west.apache.org.yaml
@@ -733,7 +733,7 @@ vhosts_asf::vhosts::vhosts:
       <Location />
         AuthLDAPUrl "ldaps://ldap2-us-west.apache.org ldap-lb-us.apache.org/ou=people,dc=apache,dc=org?uid"
         AuthLDAPRemoteUserAttribute uid
-        AuthName "PMC Members Only"
+        AuthName "ASF Committers"
         AuthType Basic
         AuthBasicProvider ldap
         Require valid-user

--- a/data/nodes/proxy3-us-west.apache.org.yaml
+++ b/data/nodes/proxy3-us-west.apache.org.yaml
@@ -733,7 +733,7 @@ vhosts_asf::vhosts::vhosts:
       <Location />
         AuthLDAPUrl "ldaps://ldap2-us-west.apache.org ldap-lb-us.apache.org/ou=people,dc=apache,dc=org?uid"
         AuthLDAPRemoteUserAttribute uid
-        AuthName "PMC Members Only"
+        AuthName "ASF Committers"
         AuthType Basic
         AuthBasicProvider ldap
         Require valid-user

--- a/data/nodes/tools-vm.apache.org.yaml
+++ b/data/nodes/tools-vm.apache.org.yaml
@@ -215,7 +215,7 @@ vhosts_asf::vhosts::vhosts:
       <Location />
         AuthLDAPUrl "ldaps://snappy5.apache.org ldap-lb-eu.apache.org/ou=people,dc=apache,dc=org?uid"
         AuthLDAPRemoteUserAttribute uid
-        AuthName "PMC Members Only"
+        AuthName "ASF Committers"
         AuthType Basic
         AuthBasicProvider ldap
         <RequireAny>


### PR DESCRIPTION
It's misleading to prompt "PMC Members Only" when the requirement is merely ASF committership