### PR TITLE
Fixed committer ids for ratis.

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -363,7 +363,7 @@ qpid={ldap:cn=qpid,ou=groups,dc=apache,dc=org}
 qpid-pmc={reuse:pit-authorization:qpid-pmc}
 edgent=cazen,djd,dlaboss,home4slc,kathyssaunders,queeniema,vdogaru,wcmarsha
 ranger=alok,bganesan,bosco,coheigea,ddas,dillidorai,gates,gautam,humbedooh,jghoman,kminder,lmccay,madhan,omalley,rmani,sneethir,sradia,vel
-ratis=jing9,szetetszwo,enis,aengineer,arp,cnauroth,jghoman,mayank_bansal,xyao,liuml07,umamahesh,jitendra,devaraj,gtCarrera9,hanishakoneru,xiaobingo,cliang
+ratis=jing9,szetszwo,enis,aengineer,arp,cnauroth,jghoman,mayank,xyao,liuml07,umamahesh,jitendra,ddas,gtcarrera9,hanishakoneru,xiaobingo,cliang
 rave={ldap:cn=rave,ou=groups,dc=apache,dc=org}
 rave-pmc={reuse:pit-authorization:rave-pmc}
 reef={ldap:cn=reef,ou=groups,dc=apache,dc=org}


### PR DESCRIPTION
Following ids fixed:
szetszwo, mayank, ddas, gtcarrera9