### PR TITLE
allow LDAP attribute to be specified in authorization templates

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -219,7 +219,7 @@ ignite-pmc={reuse:pit-authorization:ignite-pmc}
 # httpd-emeritus=AndrewWilson,akosut,awm,bhyde,brianb,brianp,cliff,davidw,dreid,drtr,fanf,grisha,ianh,jgallacher,jwoolley,marc,nlehuen,randy,rbb,ridruejo,robh,rst,sameer,stas,stoddard,thommay
 impala=abehm,brock,casey,cws,dhecht,dtsirogiannis,henry,ishaan,jbapple,jrussell,jyu,kwho,lskuff,marcel,mgrund,mjacobs,sailesh,skye,tarasbob,tarmstrong,todd,tomwhite
 # imperius=stoddard,clr,kevan,fhanik,prabalig,jneeraj,ebengston,macsun,michaelknunez,dawood,xiping
-incubator={ldap:cn=incubator,ou=groups,dc=apache,dc=org}
+incubator={ldap:cn=incubator,ou=project,ou=groups,dc=apache,dc=org;attr=member}
 incubator-pmc={reuse:pit-authorization:incubator-pmc}
 isis={ldap:cn=isis,ou=groups,dc=apache,dc=org}
 isis-pmc={reuse:pit-authorization:isis-pmc}

--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -59,7 +59,7 @@
 # to see if newuser is in the list
 
 [groups]
-committers={ldap:cn=committers,ou=groups,dc=apache,dc=org}
+committers={ldap:cn=committers,ou=groups,dc=apache,dc=org;attr=memberUid}
 
 # Don't remove group definitions from this file if pit-authorization-template
 # refers to them.

--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -142,7 +142,7 @@ ignite={reuse:asf-authorization:ignite}
 ignite-pmc={ldap:cn=ignite,ou=pmc,ou=committees,ou=groups,dc=apache,dc=org}
 # imperius={reuse:asf-authorization:# imperius}
 incubator={reuse:asf-authorization:incubator}
-incubator-pmc={ldap:cn=incubator,ou=pmc,ou=committees,ou=groups,dc=apache,dc=org}
+incubator-pmc={ldap:cn=incubator,ou=project,ou=groups,dc=apache,dc=org;attr=owner}
 isis={reuse:asf-authorization:isis}
 isis-pmc={ldap:cn=isis,ou=pmc,ou=committees,ou=groups,dc=apache,dc=org}
 jackrabbit={reuse:asf-authorization:jackrabbit}

--- a/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
+++ b/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
@@ -93,7 +93,7 @@ sub rebuild {
             die "Uh-oh: found '@lines', expected one line; at '$_'" unless @lines == 1;
             $_ = $lines[0];
         }
-        if ( $_ !~ m/^#/ && $_ =~ m/{ldap:(cn=[^;]*);?(.*)}/ ) {
+        if ( $_ !~ m/^#/ && $_ =~ m/{ldap:(cn=[^;\s}]*);?([^\s}]*)}/ ) {
             my ( $dn, $opts ) = ( $1, $2 );
             chomp;
             my @groupdn = split( /,/, $dn );

--- a/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
+++ b/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
@@ -93,7 +93,7 @@ sub rebuild {
             die "Uh-oh: found '@lines', expected one line; at '$_'" unless @lines == 1;
             $_ = $lines[0];
         }
-        if ( $_ !~ m/^#/ && $_ =~ m/{ldap:(cn=.+?)(?:;(.*)|)}/ ) {
+        if ( $_ !~ m/^#/ && $_ =~ m/{ldap:(cn=[^;]*);?(.*)}/ ) {
             my ( $dn, $opts ) = ( $1, $2 );
             chomp;
             my @groupdn = split( /,/, $dn );

--- a/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
+++ b/modules/subversion_server/files/scripts/authorization/gen_asf-authorization.pl
@@ -93,15 +93,17 @@ sub rebuild {
             die "Uh-oh: found '@lines', expected one line; at '$_'" unless @lines == 1;
             $_ = $lines[0];
         }
-        if ($_ !~ m/^#/ && $_ =~ m/{ldap:(cn=.+)}/ ) {
+        if ( $_ !~ m/^#/ && $_ =~ m/{ldap:(cn=.+?)(?:;(.*)|)}/ ) {
+            my ( $dn, $opts ) = ( $1, $2 );
             chomp;
-            my @groupdn = split( /,/, $1 );
+            my @groupdn = split( /,/, $dn );
             my $groupname = shift(@groupdn);
             my ( $groupbase, $membersline );
             $groupbase = join( ',', @groupdn );
             $groupname =~ s/^cn=//;
+            my $attrs = $1 if $opts && $opts =~ /attr=(.*)/;
             push( @dirtyOUwatchlist, "$groupbase" );
-            ( my @memberlist ) = getMembers( $groupname, $groupbase );
+            ( my @memberlist ) = getMembers( $groupname, $groupbase, $attrs );
 
             # Fix up for -pmc
             if ( $groupdn[0] eq "ou=pmc" ) {
@@ -154,8 +156,10 @@ sub rebuild {
 sub getMembers {
     my $gid  = shift;
     my $base = shift;
+    my $attrs = shift || 'memberUid,member';
+
     my ( @members, @entries, $attr, @attrs );
-    print "getMembers: Looking for $gid, $base\n" if ($debug);
+    print "getMembers: Looking for $gid, $base, $attrs\n" if ($debug);
 
     # Look for memberUid for posix groups and member for groupOfNames
     # No group should ever have both?
@@ -164,7 +168,7 @@ sub getMembers {
         filter => "(cn=$gid)",
         base   => "$base",
         scope  => 'one',
-        attrs  => [ 'memberUid', 'member' ]
+        attrs  => [ split( /,/, $attrs ) ]
     );
     $request->code && die $request->error;
     @entries = $request->entries;


### PR DESCRIPTION
look for ";attr=" within {ldap:} sections, and extract attribute name
if this string is present; otherwise default to memberUid,member for
backwards compatibility.

A single example of this new syntax is included in this commit.

The plans are to shortly make use of this to move PMC authorizations to
an owner attribute.