### PR TITLE
baby steps: allow secretary to create people in LDAP

### DIFF
--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -220,6 +220,15 @@ access to dn.subtree="ou=people,dc=apache,dc=org"
   by * read
   by anonymous auth
 
+## Explictly make people writable by apldap (root@ equiv) and the ASF Secretary Group
+access to dn.subtree="ou=people,dc=apache,dc=org"
+  attrs=children,entry
+  by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
+  by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
+  by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by * read
+  by anonymous auth
 
 ## Allow PMC chairs, and Hudson admins to grant job admin privs
 access to dn.subtree="ou=hudson,ou=apps,ou=groups,dc=apache,dc=org"


### PR DESCRIPTION
See: http://www.openldap.org/doc/admin24/access-control.html#What%20to%20control%20access%20to

"There are two special pseudo attributes entry and children. To read (and hence
return) a target entry, the subject must have read access to the target's entry
attribute. To perform a search, the subject must have search access to the
search base's entry attribute. To add or delete an entry, the subject must have
write access to the entry's entry attribute AND must have write access to the
entry's parent's children attribute. To rename an entry, the subject must have
write access to entry's entry attribute AND have write access to both the old
parent's and new parent's children attributes."

So note that this will grant the secretary access to delete an entry.  There is
no intent to make use of this other than for test purposes (creating and
deleting test people).  In particular, there is no intent to create higher
level whimsy tooling to delete people, as the common practice is to disable
people instead.