### PR TITLE
Change viewVC to run via gunicorn

### DIFF
--- a/data/nodes/svn01-us-west.apache.org.yaml
+++ b/data/nodes/svn01-us-west.apache.org.yaml
@@ -62,6 +62,7 @@ apbackup::uid: 9997
 
 base::basepackages:
   - svnmailer
+  - gunicorn
 
 base::hosts:
   localhost:
@@ -140,8 +141,6 @@ vhosts_asf::modules::modules:
     name: 'authz_svn'
   svn_check_path:
     name: 'svn_check_path'
-  cgi:
-    name: 'cgi'
 
 vhosts_asf::vhosts::vhosts:
   dist:
@@ -300,14 +299,17 @@ vhosts_asf::vhosts::vhosts:
       RewriteEngine On
 
       Redirect temp /viewcvs.cgi http://svn.apache.org/viewvc
+      Redirect temp /viewvc.cgi http://svn.apache.org/viewvc
       Redirect temp /viewcvs    http://svn.apache.org/viewvc
-      ScriptAlias /viewvc /usr/lib/viewvc/cgi-bin/viewvc.cgi
+      
+      # ProxyPass to gunicorn
+      ProxyPassMatch ^/viewvc/?(.*)$ http://localhost:8080/$1
+      
       # Rewrite /r123456 to viewvc
       RewriteRule ^/r(\d+)$ /viewvc?view=revision&revision=$1 [R=302,L]
       # Rewrite git-svn-id URLs to viewvc (/repos/asf/foo/trunk@123456)
       RewriteRule ^/repos/asf/[^@]+@(\d+)$ /viewvc?view=revision&revision=$1 [R=302,L]
       # The main repository
-      
       
       # tlp migrations
       
@@ -396,7 +398,14 @@ vhosts_asf::vhosts::vhosts:
       AddType  text/plain; charset=UTF-8  .rdf
       LimitXMLRequestBody 10000000
       RewriteEngine On
-      ScriptAlias /viewvc /usr/lib/viewvc/cgi-bin/viewvc.cgi
+      
+      # This is on port 80, might as well be on port 443 too!
+      Redirect temp /viewcvs.cgi https://svn.apache.org/viewvc
+      Redirect temp /viewvc.cgi https://svn.apache.org/viewvc
+      Redirect temp /viewcvs    https://svn.apache.org/viewvc
+      
+      # ProxyPass to gunicorn
+      ProxyPassMatch ^/viewvc/?(.*)$ http://localhost:8080/$1
       
       # Rewrite /r123456 to viewvc
       RewriteRule ^/r(\d+)$ /viewvc?view=revision&revision=$1 [R=302,L]

--- a/data/nodes/svn01-us-west.apache.org.yaml
+++ b/data/nodes/svn01-us-west.apache.org.yaml
@@ -62,7 +62,6 @@ apbackup::uid: 9997
 
 base::basepackages:
   - svnmailer
-  - gunicorn
 
 base::hosts:
   localhost:
@@ -105,6 +104,10 @@ perl::module:
     name: 'Net::LDAP'
     use_package : true
 
+python::python_pips:
+  gunicorn:
+    ensure: present
+    
 # svn01 gets to talk directly to hermes to bypass spam filters
 # on commit messages (svnmailer)
 

--- a/modules/subversion_server/manifests/init.pp
+++ b/modules/subversion_server/manifests/init.pp
@@ -621,6 +621,8 @@ class subversion_server (
   # -w 10 == 10 workers, we can up that if need be.
   exec { 'cd /usr/lib/viewvc/cgi-bin/ && gunicorn -w 10 -b 127.0.0.1:8080 -d viewvc-wsgi:application':
     path   => '/usr/bin:/usr/sbin:/bin',
+    user    => 'www-data',
+    group   => 'www-data',
     onlyif => '! ps x | grep -q gunicorn',
   }
 

--- a/modules/subversion_server/manifests/init.pp
+++ b/modules/subversion_server/manifests/init.pp
@@ -624,5 +624,4 @@ class subversion_server (
     onlyif => '! ps x | grep -q gunicorn',
   }
 
-
 }

--- a/modules/subversion_server/manifests/init.pp
+++ b/modules/subversion_server/manifests/init.pp
@@ -615,5 +615,14 @@ class subversion_server (
     ip           => $::ipaddress,
     host_aliases => $::fqdn,
   }
+  
+  # Gunicorn for viewvc
+  # Run this command unless gunicorn is already running.
+  # -w 10 == 10 workers, we can up that if need be.
+  exec { 'cd /usr/lib/viewvc/cgi-bin/ && gunicorn -w 10 -b 127.0.0.1:8080 -d viewvc-wsgi:application':
+    path   => '/usr/bin:/usr/sbin:/bin',
+    onlyif => '! ps x | grep -q gunicorn',
+  }
+
 
 }


### PR DESCRIPTION
This switches from CGI to Gunicorn via proxy.
Puppet will check if gunicorn is running (the ps|grep bit), and if not, launch it in daemon mode.
This also addresses some ViewVC aliases we had left out.