### PR TITLE
use force if rewrite is detected (and allowed)

### DIFF
--- a/modules/gitbox/files/asfgit/hooks/sync.py
+++ b/modules/gitbox/files/asfgit/hooks/sync.py
@@ -15,8 +15,12 @@ def main():
     os.chdir("/x1/repos/asf/%s.git" % cfg.repo_name)
     try:
        for ref in git.stream_refs(sys.stdin):
-          print("Syncing %s..." % ref.name)
-          subprocess.check_call(["git", "push", ghurl, "%s:%s" % (ref.newsha, ref.name)])
+          if ref.is_rewrite():
+             print("Syncing %s (FORCED)..." % ref.name)
+             subprocess.check_call(["git", "push", "-f", ghurl, "%s:%s" % (ref.newsha, ref.name)])
+          else:
+             print("Syncing %s..." % ref.name)
+             subprocess.check_call(["git", "push", ghurl, "%s:%s" % (ref.newsha, ref.name)])
     except subprocess.CalledProcessError as err:
         util.abort("Could not sync with GitHub: %s" % err.output)
 


### PR DESCRIPTION
If a force push is required, use -f to push to github with force.
Ref: INFRA-14039
Otherwise, do a normal push.