### PR TITLE
enable whimsy to submit subreqs on behalf of committers

### DIFF
--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -647,7 +647,7 @@ whimsysvn = r
 
 [/infrastructure/trunk/mlreq]
 acrequser = rw
-whimsysvn = rw
+whimsysvn = r
 @member = rw
 @pmc-chairs = rw
 @ea = rw
@@ -659,7 +659,7 @@ mostarda = rw
 whimsysvn = rw
 
 [/infrastructure/trunk/subreq]
-whimsysvn = r
+whimsysvn = rw
 apezmlm = rw
 @member = rw
 


### PR DESCRIPTION
This time get the directory correct.

reverts https://github.com/apache/infrastructure-puppet/commit/613ef169d508867ae2ddc165204ecf5ee3ecef21