### PR TITLE
Redirect to current so still works when transitioning to new instance

### DIFF
--- a/data/nodes/whimsy-vm4.apache.org.yaml
+++ b/data/nodes/whimsy-vm4.apache.org.yaml
@@ -94,7 +94,7 @@ vhosts_whimsy::vhosts::vhosts:
     docroot: '/var/www'
     error_log_file: 'whimsy_error.log'
     custom_fragment: |
-      RedirectMatch permanent ^/(.*)$ https://whimsy.apache.org/$1
+      RedirectMatch permanent ^/(.*)$ https://whimsy4.apache.org/$1
 
   whimsy-vm-443:
     vhost_name: '*'


### PR DESCRIPTION
Whilst the existing redirect works, it would need to be changed if a new instance is created and made current.