### PR TITLE
Syntax error - remove leading '+'

### DIFF
--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -1099,7 +1099,7 @@ openejb-tck = r
 [/travel-assistance]
 @member = rw
 @svnadmins = rw
-+@ea = rw
+@ea = rw
 * =
 
 [/travel-assistance/past-recipients]


### PR DESCRIPTION
Obvious syntax error:

https://github.com/apache/infrastructure-puppet/blob/4511dd63e3725ba1ba0f55031789f64d16bd719c/modules/subversion_server/files/authorization/pit-authorization-template#L1102

Line should not start with '+'