### PR TITLE
Blur/Horn retired; allow SVN sites to be dropped

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -954,9 +954,6 @@ buildbot = rw
 [/incubator/beam]
 @incubator = rw
 
-[/incubator/blur]
-* = r
-
 [/incubator/callback]
 @incubator = rw
 
@@ -980,9 +977,6 @@ buildbot = rw
 * = r
 
 [/incubator/heraldry]
-* = r
-
-[/incubator/horn]
 * = r
 
 [/incubator/htrace]


### PR DESCRIPTION
This will allow the the following to be deleted:

https://svn.apache.org/repos/asf/incubator/blur/

It only contains obsolete site data.

The following has already been removed, so the auth entry is useless:
https://svn.apache.org/repos/asf/incubator/horn/

