### PR TITLE
Datadog Disk monitoring 

### DIFF
--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -241,9 +241,15 @@ file:
     owner: 'dd-agent'
     group: 'dd-agent'
     content: |
-      # This file is overwritten upon Agent upgrade.
-      # To make modifications to the check configuration, please copy this file
-      # to `disk.yaml` and make your changes on that file.
+      # This file is managed by Puppet in the base 1604.yaml
+      # and will be overwritten automatically. 
+
+      init_config:
+
+      instances:
+       # The use_mount parameter will instruct the check to collect disk
+       # and fs metrics using mount points instead of volumes
+       - use_mount: yes
 
       init_config:
 

--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -240,7 +240,7 @@ file:
     path: '/etc/dd-agent/conf.d/disk.yaml'
     owner: 'dd-agent'
     group: 'dd-agent'
-    notify: Service['datadog-agent']
+    notify: Service[datadog-agent]
     content: |
       # This file is managed by Puppet in the base 1404.yaml
       # and will be overwritten automatically. 

--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -240,16 +240,10 @@ file:
     path: '/etc/dd-agent/conf.d/disk.yaml'
     owner: 'dd-agent'
     group: 'dd-agent'
+    notify: Service['datadog-agent']
     content: |
-      # This file is managed by Puppet in the base 1604.yaml
+      # This file is managed by Puppet in the base 1404.yaml
       # and will be overwritten automatically. 
-
-      init_config:
-
-      instances:
-       # The use_mount parameter will instruct the check to collect disk
-       # and fs metrics using mount points instead of volumes
-       - use_mount: yes
 
       init_config:
 

--- a/data/ubuntu/1604.yaml
+++ b/data/ubuntu/1604.yaml
@@ -241,9 +241,8 @@ file:
     owner: 'dd-agent'
     group: 'dd-agent'
     content: |
-      # This file is overwritten upon Agent upgrade.
-      # To make modifications to the check configuration, please copy this file
-      # to `disk.yaml` and make your changes on that file.
+      # This file is managed by Puppet in the base 1604.yaml
+      # and will be overwritten automatically. 
 
       init_config:
 

--- a/data/ubuntu/1604.yaml
+++ b/data/ubuntu/1604.yaml
@@ -240,6 +240,7 @@ file:
     path: '/etc/dd-agent/conf.d/disk.yaml'
     owner: 'dd-agent'
     group: 'dd-agent'
+    notify: Service['datadog-agent']
     content: |
       # This file is managed by Puppet in the base 1604.yaml
       # and will be overwritten automatically. 

--- a/data/ubuntu/1604.yaml
+++ b/data/ubuntu/1604.yaml
@@ -240,7 +240,7 @@ file:
     path: '/etc/dd-agent/conf.d/disk.yaml'
     owner: 'dd-agent'
     group: 'dd-agent'
-    notify: Service['datadog-agent']
+    notify: Service[datadog-agent]
     content: |
       # This file is managed by Puppet in the base 1604.yaml
       # and will be overwritten automatically. 


### PR DESCRIPTION
base yaml now writes a file (disk.yaml) and then restarts the datadog-agent service if the file has been changed.