### PR TITLE
Jenkins Node Monitor

### DIFF
--- a/data/nodes/tools-vm.apache.org.yaml
+++ b/data/nodes/tools-vm.apache.org.yaml
@@ -10,6 +10,7 @@ classes:
   - etherpad_lite
   - etherpad_lite::site
   - git_self_serve::tools
+  - jenkins_node_monitor
   - loggy
   - selfserve
   - ssl::name::wildcard_apache_org
@@ -44,6 +45,14 @@ base::basepackages:
   - 'lua5.2-sec'
   - 'mod-lua-asf'
   - 'nodejs'
+
+cron:
+  # JNM: Jenkins Node Monitor, check status of Jenkins nodes and pushes that to DataDog
+  jnm:
+    user: 'root'
+    minute: '*/10'
+    hour: '*'
+    command: 'cd /usr/local/etc/jenkins_node_monitor/ && python jnm.py > /dev/null 2>&1'
   
 elasticsearch::init_defaults:
   ES_HEAP_SIZE: '2g'

--- a/modules/jenkins_node_monitor/files/jnm.py
+++ b/modules/jenkins_node_monitor/files/jnm.py
@@ -4,8 +4,7 @@
 import ConfigParser
 from datadog import initialize, api
 from datadog.api.constants import CheckStatus
-import json
-import urllib
+import requests
 
 config = ConfigParser.ConfigParser()
 config.read("settings.cfg")
@@ -14,8 +13,7 @@ initialize(**options)
 
 url = "https://builds.apache.org/computer/api/json"
 check = 'jenkinsNode.status'
-response = urllib.urlopen(url)
-jenkinsNodes = json.loads(response.read())
+jenkinsNodes = requests.get(url).json()
 
 for node in jenkinsNodes["computer"]:
     if (node["offline"]==True):

--- a/modules/jenkins_node_monitor/files/jnm.py
+++ b/modules/jenkins_node_monitor/files/jnm.py
@@ -1,0 +1,28 @@
+# This script pulls the Jenkins node displayName, offline status, and offlineCauseReason
+# then posts it to DataDog as a custom service check. 
+
+import ConfigParser
+from datadog import initialize, api
+from datadog.api.constants import CheckStatus
+import json
+import urllib
+
+config = ConfigParser.ConfigParser()
+config.read("settings.cfg")
+options = {'api_key': config.get("datadog_agent", "api_key")}
+initialize(**options)
+
+url = "https://builds.apache.org/computer/api/json"
+check = 'jenkinsNode.status'
+response = urllib.urlopen(url)
+jenkinsNodes = json.loads(response.read())
+
+for node in jenkinsNodes["computer"]:
+    if (node["offline"]==True):
+        host = node["displayName"]
+        status = CheckStatus.CRITICAL # equals 2
+    if (node["offline"]==False):
+        host = node["displayName"]
+        status = CheckStatus.OK # equals 0
+    
+    api.ServiceCheck.check(check=check, host_name=host, status=status, message=node["offlineCauseReason"])

--- a/modules/jenkins_node_monitor/files/jnm.py
+++ b/modules/jenkins_node_monitor/files/jnm.py
@@ -2,14 +2,13 @@
 # then posts it to DataDog as a custom service check. 
 
 import ConfigParser
-from datadog import initialize, api
-from datadog.api.constants import CheckStatus
+import datadog
 import requests
 
 config = ConfigParser.ConfigParser()
 config.read("settings.cfg")
 options = {'api_key': config.get("datadog_agent", "api_key")}
-initialize(**options)
+datadog.initialize(**options)
 
 url = "https://builds.apache.org/computer/api/json"
 check = 'jenkinsNode.status'
@@ -18,9 +17,9 @@ jenkinsNodes = requests.get(url).json()
 for node in jenkinsNodes["computer"]:
     if (node["offline"]==True):
         host = node["displayName"]
-        status = CheckStatus.CRITICAL # equals 2
+        status = 2 # CheckStatus.CRITICAL
     if (node["offline"]==False):
         host = node["displayName"]
-        status = CheckStatus.OK # equals 0
+        status = 0 # CheckStatus.OK
     
-    api.ServiceCheck.check(check=check, host_name=host, status=status, message=node["offlineCauseReason"])
+    datadog.api.ServiceCheck.check(check=check, host_name=host, status=status, message=node["offlineCauseReason"])

--- a/modules/jenkins_node_monitor/manifests/init.pp
+++ b/modules/jenkins_node_monitor/manifests/init.pp
@@ -1,0 +1,33 @@
+#/etc/puppet/modules/jenkins_node_monitor/manifests/init.pp
+
+class jenkins_node_monitor (
+  $shell          = '/bin/bash',
+  $username       = 'root',
+  $group          = 'root',
+){
+  require python
+
+  python::pip {
+    'datadog' :
+      ensure  => present;
+  }
+
+  file {
+    '/usr/local/etc/jenkins_node_monitor':
+      ensure => directory,
+      mode   => '0755',
+      owner  => $username,
+      group  => $group;
+    '/usr/local/etc/jenkins_node_monitor/jnm.py':
+      mode   => '0755',
+      owner  => $username,
+      group  => $group,
+      source => 'puppet:///modules/jenkins_node_monitor/jnm.py';
+    '/usr/local/etc/jenkins_node_monitor/settings.cfg':
+      ensure  => present,
+      content => template('jenkins_node_monitor/settings.cfg.erb'),
+      owner  => $username,
+      group  => $group,
+      mode    => '0644';
+  }
+}

--- a/modules/jenkins_node_monitor/templates/settings.cfg.erb
+++ b/modules/jenkins_node_monitor/templates/settings.cfg.erb
@@ -1,0 +1,3 @@
+[datadog_agent]
+api_key: <%= scope['datadog_agent::api_key'] %>
+


### PR DESCRIPTION
New module that pulls node and status from builds.a.o and pushes that data to DataDog as a custom service check.