### PR TITLE
Adding two excludes as Docker throws a ton of warnings into syslog.

### DIFF
--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -253,6 +253,8 @@ file:
        - use_mount: yes
          excluded_filesystems:
            - tracefs
+           - none
+           - shm
 
 ldapclient::install::ubuntu::1404::tlscertpath:  '/etc/ldap/cacerts/ldap-client.pem'
 ldapclient::install::ubuntu::1404::pamhostcheck: 'yes'

--- a/data/ubuntu/1604.yaml
+++ b/data/ubuntu/1604.yaml
@@ -253,6 +253,8 @@ file:
        - use_mount: yes
          excluded_filesystems:
            - tracefs
+           - none
+           - shm
 
 ldapclient::install::ubuntu::1604::tlscertpath:  '/etc/ldap/cacerts/ldap-client.pem'
 ldapclient::install::ubuntu::1604::pamhostcheck: 'yes'


### PR DESCRIPTION
Adding two excludes as Docker throws a ton of warnings into syslog.