### PR TITLE
Removing vhosts_asf::vhosts class as it's no longer needed and causing errors

### DIFF
--- a/data/nodes/snappy1.apache.org.yaml
+++ b/data/nodes/snappy1.apache.org.yaml
@@ -12,7 +12,6 @@ classes:
   - oraclejava::install
   - ssl::name::wildcard_apache_org
   - vhosts_asf::modules
-  - vhosts_asf::vhosts
 
 base::basepackages:
   - 'lua5.2'

--- a/data/nodes/snappy2.apache.org.yaml
+++ b/data/nodes/snappy2.apache.org.yaml
@@ -12,7 +12,6 @@ classes:
   - ssl::name::wildcard_apache_org
   - oraclejava::install
   - vhosts_asf::modules
-  - vhosts_asf::vhosts
 
 vhosts_asf::modules::modules:
   allowmethods:


### PR DESCRIPTION
Removing vhosts_asf::vhosts class as it's no longer needed and causing errors