### PR TITLE
Add Symlinking for JDK9 to latest1.9 - Keeping 1.8 as latest for the time being.

### DIFF
--- a/modules/build_slaves/manifests/jenkins.pp
+++ b/modules/build_slaves/manifests/jenkins.pp
@@ -367,6 +367,10 @@ class build_slaves::jenkins (
     ensure => link,
     target => '/usr/local/asfpackages/java/jdk1.8.0_144',
   }
+  file { '/home/jenkins/tools/java/latest1.9':
+    ensure => link,
+    target => '/usr/local/asfpackages/java/jdk-9-b181-unlimited-security',
+  }
 
   cron {
     'docker-cleanup':

--- a/modules/buildbot_slave/manifests/buildbot.pp
+++ b/modules/buildbot_slave/manifests/buildbot.pp
@@ -106,5 +106,9 @@ class buildbot_slave::buildbot (
     ensure => link,
     target => '/usr/local/asfpackages/java/jdk1.8.0_144',
   }
+  file { '/home/buildslave/slave/tools/java/latest1.9':
+    ensure => link,
+    target => '/usr/local/asfpackages/java/jdk-9-b181-unlimited-security',
+  }
 
 }


### PR DESCRIPTION
Add Symlinking for JDK9 to latest1.9 - Keeping 1.8 as latest for the time being.