### PR TITLE
bump mbox size limit to 4GB

### DIFF
--- a/data/nodes/mbox-vm.apache.org.yaml
+++ b/data/nodes/mbox-vm.apache.org.yaml
@@ -10,6 +10,7 @@ postfix::server::mailbox_command: '/usr/bin/procmail -a "$EXTENSION"'
 postfix::server::myorigin: 'apache.org'
 postfix::server::mynetworks: '140.211.11.3/32'
 postfix::server::mail_user: 'apmail'
+postfix::server::message_size_limit: '4294967295'
 postfix::server::smtpd_recipient_restrictions:
   - 'permit_mynetworks'
   - 'reject'


### PR DESCRIPTION
bump mbox size limit to 4GB