### PR TITLE
Log more on error

### DIFF
--- a/modules/mboxer/files/tools/archive.py
+++ b/modules/mboxer/files/tools/archive.py
@@ -127,6 +127,8 @@ def main():
         listpath = os.path.join(fqdnpath, listname)
         path = os.path.join(listpath, "%s.mbox" % YM)
         print("This is for %s, archiving under %s!" % (recipient, path))
+        # Show some context in case the IO fails:
+        print("Return-Path: %s" % msg.get('Return-Path'))
         if not os.path.exists(listpath):
             print("Creating directory %s first" % listpath)
             os.makedirs(listpath, exist_ok = True)

--- a/modules/mboxer/files/tools/archive.py
+++ b/modules/mboxer/files/tools/archive.py
@@ -129,6 +129,7 @@ def main():
         print("This is for %s, archiving under %s!" % (recipient, path))
         # Show some context in case the IO fails:
         print("Return-Path: %s" % msg.get('Return-Path'))
+        print("Message-Id: %s" % msg.get('Message-Id'))
         if not os.path.exists(listpath):
             print("Creating directory %s first" % listpath)
             os.makedirs(listpath, exist_ok = True)


### PR DESCRIPTION
If the script fails, all the output will be written to syslog.
At present the output does not identify the message; add some context to make it easier to track errors