### PR TITLE
Revert "prep for service workers"

### DIFF
--- a/data/nodes/whimsy-vm4.apache.org.yaml
+++ b/data/nodes/whimsy-vm4.apache.org.yaml
@@ -170,14 +170,6 @@ vhosts_whimsy::vhosts::vhosts:
       - /board/publish_minutes
 
     custom_fragment: |
-      # Allow access to bootstrapping files without authorization
-      <Directory /srv/whimsy/www/board/agenda>
-        Require expr %{REQUEST_URI} =~ m#^/board/agenda/stylesheets/app.css#
-        Require expr %{REQUEST_URI} =~ m#^/board/agenda/app.js#
-        Require expr %{REQUEST_URI} =~ m#^/board/agenda/[-\d]+/bootstrap.html#
-        Require ldap-group cn=committers,ou=groups,dc=apache,dc=org
-      </Directory>
-
       RemoteIPHeader X-Forwarded-For
 
       SetEnv PATH /usr/local/rvm/wrappers/ruby-%{hiera('ruby_version')}:${PATH}


### PR DESCRIPTION
Two problems:

1) I forgot about the need to do puppet escaping %%{}{...}

2) This addition is placed in the wrong part of the config file; it needs
   to go after the generated board agenda authentication.

Reverting until I can properly address both problems.

This reverts commit d786e2e6d1f87b636856e53e13256d5ebd66925d.