### PR TITLE
INFRA-15193 - mboxer/archive.py does not work for mail aliases

### DIFF
--- a/modules/mboxer/files/tools/archive.py
+++ b/modules/mboxer/files/tools/archive.py
@@ -114,17 +114,18 @@ def main():
     recipient = args.lid
 
     # If not, try List-Post
-    if not recipient and msg.get('list-post'):
-        header = msg.get('list-post')
-        print(header)
-        # Only expecting apache.org or apachecon.com lists
-        m = re.match(r"<mailto:(.+?@(.*apache\.org|apachecon\.com))>", header)
-        if m:
-            recipient = m.group(1)
-        else:
-            print("Unexpected list-post: %s" % header)
-    else:
-        print("Missing list-post: %s" % msg.get_unixfrom())
+    if not recipient:
+		if msg.get('list-post'):
+			header = msg.get('list-post')
+			print(header)
+			# Only expecting apache.org or apachecon.com lists
+			m = re.match(r"<mailto:(.+?@(.*apache\.org|apachecon\.com))>", header)
+			if m:
+				recipient = m.group(1)
+			else:
+				print("Unexpected list-post: %s" % header)
+		else:
+			print("Missing list-post: %s" % msg.get_unixfrom())
     
     # If no bueno, try Received headers
     if not recipient and msg.get('received'):

--- a/modules/mboxer/files/tools/archive.py
+++ b/modules/mboxer/files/tools/archive.py
@@ -115,17 +115,17 @@ def main():
 
     # If not, try List-Post
     if not recipient:
-		if msg.get('list-post'):
-			header = msg.get('list-post')
-			print(header)
-			# Only expecting apache.org or apachecon.com lists
-			m = re.match(r"<mailto:(.+?@(.*apache\.org|apachecon\.com))>", header)
-			if m:
-				recipient = m.group(1)
-			else:
-				print("Unexpected list-post: %s" % header)
-		else:
-			print("Missing list-post: %s" % msg.get_unixfrom())
+        if msg.get('list-post'):
+            header = msg.get('list-post')
+            print(header)
+            # Only expecting apache.org or apachecon.com lists
+            m = re.match(r"<mailto:(.+?@(.*apache\.org|apachecon\.com))>", header)
+            if m:
+                recipient = m.group(1)
+            else:
+                print("Unexpected list-post: %s" % header)
+        else:
+            print("Missing list-post: %s" % msg.get_unixfrom())
     
     # If no bueno, try Received headers
     if not recipient and msg.get('received'):


### PR DESCRIPTION
Added --lid option to allow list mail address to be specified
e.g. for aliases which don't have a List-Post or where the List-Post is incorrect