### PR TITLE
Changing mail relay on jenkins-master from mail.a.o to mailrelay1-us-west.a.o

### DIFF
--- a/data/nodes/jenkins-master.apache.org.yaml
+++ b/data/nodes/jenkins-master.apache.org.yaml
@@ -63,6 +63,8 @@ logrotate::rule:
     missingok: true
     rotate_every: 'day'
 
+postfix::server::relayhost: 'mailrelay1-us-west.apache.org'
+
 rsync::package_ensure:        'latest'
 rsync::server::use_xinetd:    false
 rsync::server::gid:           'nogroup'


### PR DESCRIPTION
Changing mail relay on jenkins-master from mail.a.o to mailrelay1-us-west.a.o