### PR TITLE
Add alias archive endpoints for email aliases

### DIFF
--- a/modules/mboxer/manifests/init.pp
+++ b/modules/mboxer/manifests/init.pp
@@ -54,5 +54,35 @@ mailalias {
       name      => 'restricted',
       provider  => aliases,
       recipient => "|python3 ${install_base}/tools/archive.py restricted";
+    'chairman':
+      ensure    => present,
+      name      => 'chairman',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid chairman@apache.org";
+    'ea':
+      ensure    => present,
+      name      => 'ea',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid ea@apache.org";
+    'president':
+      ensure    => present,
+      name      => 'president',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid president@apache.org";
+    'secretary':
+      ensure    => present,
+      name      => 'secretary',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid secretary@apache.org";
+    'treasurer':
+      ensure    => present,
+      name      => 'treasurer',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid treasurer@apache.org";
+    'zztest':
+      ensure    => present,
+      name      => 'zztest',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py --lid zztest@infra.apache.org";
   }
 }


### PR DESCRIPTION
These archive aliases are to allow mail aliases such as secretary@ to be archived.

There is also a test alias