### PR TITLE
remove rbldnsd from devops - nothing is using it, and it's generating…

### DIFF
--- a/data/nodes/devops.apache.org.yaml
+++ b/data/nodes/devops.apache.org.yaml
@@ -1,6 +1,5 @@
 ---
 classes: 
-  - rbldnsd::master::setup
   - puppet_asf::master
   - datadog_asf::integrations::snmp
   - dell


### PR DESCRIPTION
… thousands of cron errors