### PR TITLE
move postfix::dbfile create_resources call to base along with the oth…

### DIFF
--- a/data/nodes/mx1-lw-eu.apache.org.yaml
+++ b/data/nodes/mx1-lw-eu.apache.org.yaml
@@ -3,7 +3,6 @@ classes:
   - loggy
   - kif
   - mx_asf
-  - postfix_asf
   - ssl::name::wildcard_apache_org
 
 postfix::server::inet_interfaces: 'all'
@@ -35,3 +34,4 @@ postfix::dbfile:
       stevenn@outerthought.org   REJECT      
       admin@hkug.org     REJECT
       2066044032@qq.com  REJECT
+      test@test.test  REJECT

--- a/data/nodes/mx1-lw-us.apache.org.yaml
+++ b/data/nodes/mx1-lw-us.apache.org.yaml
@@ -3,7 +3,6 @@ classes:
   - kif
   - loggy
   - mx_asf
-  - postfix_asf
   - ssl::name::wildcard_apache_org
 
 postfix::server::inet_interfaces: 'all'
@@ -35,3 +34,4 @@ postfix::dbfile:
       stevenn@outerthought.org   REJECT      
       admin@hkug.org     REJECT
       2066044032@qq.com  REJECT
+      test@test.test  REJECT

--- a/modules/base/manifests/init.pp
+++ b/modules/base/manifests/init.pp
@@ -95,6 +95,9 @@ class base (
   $venvs = hiera_hash('python::venv',{})
   create_resources(python::virtualenv, $venvs)
 
+  $dbfile = hiera_hash('postfix::dbfile', {})
+  create_resources(postfix::dbfile, $dbfile)
+
   class { "base::install::${::asfosname}::${::asfosrelease}":
   }
 }


### PR DESCRIPTION
…ers. remove postfix_asf module that brokenly redeclares sender_access. this should be handled entirely in yaml via create_resources and the postfix module