### PR TITLE
Adding puppetlabs-registry to Puppetfile and then using it to enable long file paths on the Jenkins Windows node.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -297,3 +297,7 @@ mod 'download_file',
 mod 'puppetlabs-powershell',
   :git => 'https://github.com/puppetlabs/puppetlabs-powershell',
   :tag => '2.1.2'
+
+mod 'puppetlabs-registry',
+  :git => 'https://github.com/puppetlabs/puppetlabs-registry',
+  :tag => '1.1.4'

--- a/environments/windows/modules/jenkins_slave_windows/manifests/init.pp
+++ b/environments/windows/modules/jenkins_slave_windows/manifests/init.pp
@@ -21,10 +21,10 @@ class jenkins_slave_windows (
     ensure => directory
   }
 
-include jenkins_slave_windows::params
+  include jenkins_slave_windows::params
 
-class {'jenkins_slave_windows::download': } ->
-class {'jenkins_slave_windows::install': }
+  class {'jenkins_slave_windows::download': } ->
+  class {'jenkins_slave_windows::install': }
 
 ################### create symlinks #############################
   exec { "create symlink for CMake":
@@ -83,5 +83,11 @@ class {'jenkins_slave_windows::install': }
     provider => powershell,
   }
 #################################################################
+
+  registry_value { 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled':
+    ensure => present,
+    type   => dword,
+    data   =>  1,
+  }
 
 }


### PR DESCRIPTION
Adding puppetlabs-registry to Puppetfile and then using it to enable long file paths on the Jenkins Windows node.