### PR TITLE
add .travis.yml for linting as well as lint.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+
+rvm:
+ - 2.3
+
+install:
+  - bundle install
+
+script:
+  - ./bin/lint.sh

--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export commit=$(git rev-parse HEAD)
+export files=$(git --no-pager show --pretty="" --name-only| tr '\r\n' ' ')
+bundle exec puppet-lint --no-nested_classes_or_defines-check --no-autoloader_layout-check -r $commit $files


### PR DESCRIPTION
.travis.yml installs the puppet dependencies and then just runs the bin/lint.sh script

lint.sh gets the most recent commit and files changes in that file, and then reports the linting problems

future work will report to the ticket the list of files and linting errors