### PR TITLE
use new group DN for git auth before defaulting to old

### DIFF
--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -44,7 +44,7 @@ def authorized_committers(repo_name):
     attrs = ["memberUid", "member"]
     # check new style ldap groups DN first
     try:
-        for pdn, attrs in lh.search_s(pdn, ldap.SCOPE_BASE, attrlist=attrs):
+        for ldapresult, attrs in lh.search_s(pdn, ldap.SCOPE_BASE, attrlist=attrs):
             numldap += 1
             for availid in attrs.get("memberUid", []):
                 writers.add(availid)
@@ -56,7 +56,7 @@ def authorized_committers(repo_name):
     # If new style doesn't exist, default to old style DN
     if numldap == 0:
         try:
-            for dn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
+            for ldapresult, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
                 numldap += 1
                 for availid in attrs.get("memberUid", []):
                     writers.add(availid)

--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -48,8 +48,8 @@ def authorized_committers(repo_name):
             numldap += 1
             for availid in attrs.get("memberUid", []):
                 writers.add(availid)
-            for pdn in attrs.get("member", []):
-                writers.add(DN_RE.match(pdn).group(1))
+            for result in attrs.get("member", []):
+                writers.add(DN_RE.match(result).group(1))
     except:
         log.exception()
     
@@ -60,8 +60,8 @@ def authorized_committers(repo_name):
                 numldap += 1
                 for availid in attrs.get("memberUid", []):
                     writers.add(availid)
-                for dn in attrs.get("member", []):
-                    writers.add(DN_RE.match(dn).group(1))
+                for result in attrs.get("member", []):
+                    writers.add(DN_RE.match(result).group(1))
         except:
             log.exception()
 

--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -26,12 +26,12 @@ def authorized_committers(repo_name):
         writers.add(util.decode(admin.strip()))
 
     if parser.has_option("groups", repo_name):
-        dn = parser.get("groups", repo_name).strip()
+        oldldapresults = parser.get("groups", repo_name).strip()
     else:
         # drop subproject name if present
         repo_name = SUBPROJECT_RE.sub("", repo_name)
-        dn = GROUP_DN % {"group": repo_name}
-        pdn = PGROUP_DN % {"group": repo_name}
+        oldldapresults = GROUP_DN % {"group": repo_name}
+        ldapresults = PGROUP_DN % {"group": repo_name}
 
     # Individually granted access
     if parser.has_option("individuals", repo_name):
@@ -44,24 +44,24 @@ def authorized_committers(repo_name):
     attrs = ["memberUid", "member"]
     # check new style ldap groups DN first
     try:
-        for pdn, attrs in lh.search_s(pdn, ldap.SCOPE_BASE, attrlist=attrs):
+        for ldapresults, attrs in lh.search_s(ldapresults, ldap.SCOPE_BASE, attrlist=attrs):
             numldap += 1
             for availid in attrs.get("memberUid", []):
                 writers.add(availid)
-            for pdn in attrs.get("member", []):
-                writers.add(DN_RE.match(pdn).group(1))
+            for ldapresults in attrs.get("member", []):
+                writers.add(DN_RE.match(ldapresults).group(1))
     except:
         log.exception()
     
     # If new style doesn't exist, default to old style DN
     if numldap == 0:
         try:
-            for dn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
+            for oldldapresults, attrs in lh.search_s(oldldapresults, ldap.SCOPE_BASE, attrlist=attrs):
                 numldap += 1
                 for availid in attrs.get("memberUid", []):
                     writers.add(availid)
-                for dn in attrs.get("member", []):
-                    writers.add(DN_RE.match(dn).group(1))
+                for oldldapresults in attrs.get("member", []):
+                    writers.add(DN_RE.match(oldldapresults).group(1))
         except:
             log.exception()
 

--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -44,7 +44,7 @@ def authorized_committers(repo_name):
     attrs = ["memberUid", "member"]
     # check new style ldap groups DN first
     try:
-        for pdn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
+        for pdn, attrs in lh.search_s(pdn, ldap.SCOPE_BASE, attrlist=attrs):
             numldap += 1
             for availid in attrs.get("memberUid", []):
                 writers.add(availid)

--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -42,6 +42,7 @@ def authorized_committers(repo_name):
     lh = ldap.initialize("ldaps://ldap-us-ro.apache.org")
     numldap = 0 # ldap entries fetched
     attrs = ["memberUid", "member"]
+    # check new style ldap groups DN first
     try:
         for pdn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
             numldap += 1
@@ -52,7 +53,7 @@ def authorized_committers(repo_name):
     except:
         log.exception()
     
-    # In case of LDAP move (like whimsy), use the updated DN
+    # If new style doesn't exist, default to old style DN
     if numldap == 0:
         try:
             for dn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):

--- a/modules/gitbox/files/asfgit/auth.py
+++ b/modules/gitbox/files/asfgit/auth.py
@@ -43,19 +43,19 @@ def authorized_committers(repo_name):
     numldap = 0 # ldap entries fetched
     attrs = ["memberUid", "member"]
     try:
-        for dn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
+        for pdn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
             numldap += 1
             for availid in attrs.get("memberUid", []):
                 writers.add(availid)
-            for dn in attrs.get("member", []):
-                writers.add(DN_RE.match(dn).group(1))
+            for pdn in attrs.get("member", []):
+                writers.add(DN_RE.match(pdn).group(1))
     except:
         log.exception()
     
     # In case of LDAP move (like whimsy), use the updated DN
     if numldap == 0:
         try:
-            for dn, attrs in lh.search_s(pdn, ldap.SCOPE_BASE, attrlist=attrs):
+            for dn, attrs in lh.search_s(dn, ldap.SCOPE_BASE, attrlist=attrs):
                 numldap += 1
                 for availid in attrs.get("memberUid", []):
                     writers.add(availid)


### PR DESCRIPTION
this change might not be necessary for gitbox, but i believe it was the cause of the problem we had with impala defaulting to old LDAP groups because it checks old groups first, so anyone who is getting added to the new groups isn't necessarily getting back ported to the old group
maybe I just need a sanity check :)