### PR TITLE
Add option for mails to be accessed by all committers

### DIFF
--- a/modules/mboxer/files/tools/archive.py
+++ b/modules/mboxer/files/tools/archive.py
@@ -27,6 +27,7 @@ Arguments (optional):
     <security-realm> (optional)
     - restricted - file the mail under the directory defined by the 'restricteddir' config item
     - private    - file the mail under the directory defined by the 'privatedir' config item
+    - committers - file the mail under the directory defined by the 'committersdir' config item
     - anything else, file it under the directory defined by the 'archivedir' config item
 
    The above can be combined if required.
@@ -53,6 +54,7 @@ except:
     config = {
         'archivedir': '/x1/archives',
         'restricteddir': '/x1/restricted',
+        'committersdir': '/x1/committers',
         'dumpfile': '/x1/archives/bademails.txt'
     }
 
@@ -65,7 +67,7 @@ def valid_mail(m):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--lid", type=valid_mail, help="override list id")
-parser.add_argument("security", nargs='?') # e.g. restricted, private or omitted
+parser.add_argument("security", nargs='?') # e.g. restricted, private, committers or omitted
 args = parser.parse_args()
 
 def lock(fd):
@@ -145,6 +147,8 @@ def main():
             dochmod = False
         elif args.security == 'private':
             adir = config['privatedir']
+        elif args.security == 'committers':
+            adir = config['committersdir']
         # Construct a path to the mbox file
         fqdnpath = os.path.join(adir, fqdn)
         listpath = os.path.join(fqdnpath, listname)

--- a/modules/mboxer/manifests/init.pp
+++ b/modules/mboxer/manifests/init.pp
@@ -6,6 +6,7 @@ class mboxer (
 ){
 
   $archive_dir    = '/x1/archives'
+  $committers_dir  = '/x1/committers'
   $private_dir    = '/x1/private'
   $root_dir    = '/x1/restricted'
   $install_base  = '/usr/local/etc/mboxer'
@@ -38,6 +39,11 @@ file {
       owner  => 'nobody',
       group  => 'apmail',
       mode   => '0705';
+    $committers_dir:
+      ensure => directory,
+      owner  => 'nobody',
+      group  => 'apmail',
+      mode   => '0705';
     $private_dir:
       ensure => directory,
       owner  => 'nobody',
@@ -55,6 +61,11 @@ mailalias {
       name      => 'archiver',
       provider  => aliases,
       recipient => "|python3 ${install_base}/tools/archive.py";
+    'committers':
+      ensure    => present,
+      name      => 'committers',
+      provider  => aliases,
+      recipient => "|python3 ${install_base}/tools/archive.py committers";
     'private':
       ensure    => present,
       name      => 'private',


### PR DESCRIPTION
This is intended for archiving mails to which all committers should have access.

e.g. the committers@apache.org archive