### PR TITLE
old version of setuptools is causing a failure to install loggy

### DIFF
--- a/modules/loggy/manifests/init.pp
+++ b/modules/loggy/manifests/init.pp
@@ -28,6 +28,8 @@ class loggy (
       ensure  => present;
     'pyasn1' :
       ensure  => present;
+    'setuptools':
+      ensure  => latest;
   } ->
 
   file {


### PR DESCRIPTION
another option would be to replace the system install of python-setuptools (in 14/1604.yaml) with a pip installed version but that might be too far reaching
so instead we could just add an ensure => latest to base or in the yamls for 1404/1604