### PR TITLE
make logrotate only roll httpd logs to fix borkage with rolling mirro…

### DIFF
--- a/data/nodes/git1-us-east.apache.org.yaml
+++ b/data/nodes/git1-us-east.apache.org.yaml
@@ -43,10 +43,16 @@ git_asf::daemon_directory: '/x1/git/mirrors'
 logrotate::rule:
   apache2:
     ensure: 'present'
-    path: '/x1/log/*.log'
+    path: '/x1/log/git*.log'
     delaycompress: true
     ifempty: false
-    rotate: 52
+    rotate: 4
+  apache2-error:
+    ensure: 'present'
+    path: '/x1/log/error.log'
+    delaycompress: true
+    ifempty: false
+    rotate: 4
 
 apache::logroot: '/x1/log'
 


### PR DESCRIPTION
…r update log script and improperly chowning it. reduce kept logs to 4 days.