### PR TITLE
add python3-dev to jenkins build nodes

### DIFF
--- a/data/ubuntu/1404.yaml
+++ b/data/ubuntu/1404.yaml
@@ -483,6 +483,7 @@ build_slaves::distro_packages:
   - python-boto
   - python-setuptools
   - python-support
+  - python3-dev
   - re2c
   - ruby
   - ruby-dev

--- a/data/ubuntu/1604.yaml
+++ b/data/ubuntu/1604.yaml
@@ -468,6 +468,7 @@ build_slaves::distro_packages:
   - python-all-dev
   - python-boto
   - python-setuptools
+  - python3-dev
   - re2c
   - ruby
   - ruby-dev


### PR DESCRIPTION
build-essential is provided in the same attribute and python-dev is provided by `python::dev: true`