### PR TITLE
install kubectl on jenkins-beam{1..8}

### DIFF
--- a/data/nodes/jenkins-beam1.apache.org.yaml
+++ b/data/nodes/jenkins-beam1.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam2.apache.org.yaml
+++ b/data/nodes/jenkins-beam2.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam3.apache.org.yaml
+++ b/data/nodes/jenkins-beam3.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam4.apache.org.yaml
+++ b/data/nodes/jenkins-beam4.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam5.apache.org.yaml
+++ b/data/nodes/jenkins-beam5.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam6.apache.org.yaml
+++ b/data/nodes/jenkins-beam6.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam7.apache.org.yaml
+++ b/data/nodes/jenkins-beam7.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/data/nodes/jenkins-beam8.apache.org.yaml
+++ b/data/nodes/jenkins-beam8.apache.org.yaml
@@ -1,3 +1,4 @@
 ---
 classes:
   - build_slaves::jenkins
+  - build_slaves::kube

--- a/modules/build_slaves/manifests/kube.pp
+++ b/modules/build_slaves/manifests/kube.pp
@@ -1,0 +1,12 @@
+#/etc/puppet/modules/build_slaves/manifests/kube.pp
+
+class build_slaves::kube ( ) {
+
+  exec { 'download_and_install_kubectl':
+    command => "/usr/bin/curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.9.0/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/kubectl",
+    creates => "/usr/local/bin/kubectl",
+    timeout => 600,
+    require => [Package['curl'],
+  }
+
+}


### PR DESCRIPTION
This installs kubectl with an exec, creating the executable and only running once.  This can be added in yaml (as committed) to add to any node as incorporating an entire kubernetes puppet module is overkill.  While the exec isn't ideal, for this type of binary installation it makes sense.