### PR TITLE
move broken infra site links to point at selfserve until we can move the

### DIFF
--- a/data/nodes/tools-vm.apache.org.yaml
+++ b/data/nodes/tools-vm.apache.org.yaml
@@ -407,6 +407,8 @@ vhosts_asf::vhosts::vhosts:
     serveraliases:
       - 'infrahelp.apache.org'
       - 'helpinfrahelpyou.apache.org'
+      - 'infra.apache.org'
+      - 'infrastructure.apache.org'
     serveradmin: 'root@apache.org'
     docroot: '/var/www/selfserve-portal/site'
     manage_docroot: false


### PR DESCRIPTION
actual site content