### PR TITLE
fix rsyslog rotate to work on both 1404 and 1604

### DIFF
--- a/modules/base/files/logrotate-rsyslog
+++ b/modules/base/files/logrotate-rsyslog
@@ -11,7 +11,7 @@
         delaycompress
         compress
         postrotate
-                reload rsyslog >/dev/null 2>&1 || true
+          service rsyslog rotate
         endscript
 }
 
@@ -32,6 +32,6 @@
         delaycompress
         sharedscripts
         postrotate
-                reload rsyslog >/dev/null 2>&1 || true
+          service rsyslog rotate
         endscript
 }


### PR DESCRIPTION
(and beyond)