### PR TITLE
remove extra matt block

### DIFF
--- a/modules/gitbox/manifests/init.pp
+++ b/modules/gitbox/manifests/init.pp
@@ -89,15 +89,6 @@ $pbcsPwd  = ''
       mode   => '0750';
   }
 
-  ## MATT dir
-  file {
-    '/x1/gitbox/matt':
-      ensure => directory,
-      owner  => 'www-data',
-      group  => 'www-data',
-      mode   => '0755';
-  }
-
   file {
     '/etc/gitweb':
       ensure  => directory,


### PR DESCRIPTION
the extra file{} block for /x1/gitbox/matt blocks the recurse of files
in /x1/gitbox/matt from puppet, so puppet updates don't get applied.