### PR TITLE
Allow ASF members to view /pmc/ URLs

### DIFF
--- a/data/nodes/mailprivate-vm.apache.org.yaml
+++ b/data/nodes/mailprivate-vm.apache.org.yaml
@@ -90,20 +90,16 @@ vhosts_asf::vhosts::vhosts:
       <LocationMatch ^/pmc/private-arch/$dir(.*)>
         ## Either PMC member or ASF member
         <RequireAny>
+            AuthType Basic
+            AuthBasicProvider ldap
+            AuthName "$pmc - PMC or ASF members"
+            AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
             <RequireAll>
-              AuthType Basic
-              AuthBasicProvider ldap
-              AuthName "$pmc - PMC members only."
-              AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
               AuthLDAPGroupAttribute owner
               AuthLDAPRemoteUserIsDN On
               Require ldap-group cn=$cn,ou=project,ou=groups,dc=apache,dc=org
             </RequireAll>
             <RequireAll>
-              AuthType Basic
-              AuthBasicProvider ldap
-              AuthName "ASF Members only."
-              AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
               AuthLDAPGroupAttribute memberUid
               AuthLDAPGroupAttributeIsDN Off
               Require ldap-group cn=member,ou=groups,dc=apache,dc=org

--- a/data/nodes/mailprivate-vm.apache.org.yaml
+++ b/data/nodes/mailprivate-vm.apache.org.yaml
@@ -108,7 +108,7 @@ vhosts_asf::vhosts::vhosts:
               AuthLDAPGroupAttributeIsDN Off
               Require ldap-group cn=member,ou=groups,dc=apache,dc=org
             </RequireAll>
-        <RequireAny>
+        </RequireAny>
       </LocationMatch>
       </Macro>
 

--- a/data/nodes/mailprivate-vm.apache.org.yaml
+++ b/data/nodes/mailprivate-vm.apache.org.yaml
@@ -88,15 +88,27 @@ vhosts_asf::vhosts::vhosts:
 
       <Macro MacroMboxPMC $dir $pmc $cn>
       <LocationMatch ^/pmc/private-arch/$dir(.*)>
-        <RequireAll>
-          AuthType Basic
-          AuthBasicProvider ldap
-          AuthName "$pmc - PMC members only."
-          AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
-          AuthLDAPGroupAttribute owner
-          AuthLDAPRemoteUserIsDN On
-          Require ldap-group cn=$cn,ou=project,ou=groups,dc=apache,dc=org
-        </RequireAll>
+        ## Either PMC member or ASF member
+        <RequireAny>
+            <RequireAll>
+              AuthType Basic
+              AuthBasicProvider ldap
+              AuthName "$pmc - PMC members only."
+              AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
+              AuthLDAPGroupAttribute owner
+              AuthLDAPRemoteUserIsDN On
+              Require ldap-group cn=$cn,ou=project,ou=groups,dc=apache,dc=org
+            </RequireAll>
+            <RequireAll>
+              AuthType Basic
+              AuthBasicProvider ldap
+              AuthName "ASF Members only."
+              AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
+              AuthLDAPGroupAttribute memberUid
+              AuthLDAPRemoteUserIsDN Off
+              Require ldap-group cn=member,ou=groups,dc=apache,dc=org
+            </RequireAll>
+        <RequireAny>
       </LocationMatch>
       </Macro>
 

--- a/data/nodes/mailprivate-vm.apache.org.yaml
+++ b/data/nodes/mailprivate-vm.apache.org.yaml
@@ -105,7 +105,7 @@ vhosts_asf::vhosts::vhosts:
               AuthName "ASF Members only."
               AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
               AuthLDAPGroupAttribute memberUid
-              AuthLDAPRemoteUserIsDN Off
+              AuthLDAPGroupAttributeIsDN Off
               Require ldap-group cn=member,ou=groups,dc=apache,dc=org
             </RequireAll>
         <RequireAny>
@@ -121,7 +121,7 @@ vhosts_asf::vhosts::vhosts:
           AuthName "ASF Members only."
           AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
           AuthLDAPGroupAttribute memberUid
-          AuthLDAPRemoteUserIsDN Off
+          AuthLDAPGroupAttributeIsDN Off
           Require ldap-group cn=member,ou=groups,dc=apache,dc=org
         </RequireAll>
       </LocationMatch>


### PR DESCRIPTION
As per INFRA-15650, use RequireAny to group PMC and ASF members

Note that there is no need to change the definition in the gen-httpdconfig.sh file, as that is no longer used (it was intended for dist.a.o)