### PR TITLE
Explicitly set AuthLDAPGroupAttributeIsDN On

### DIFF
--- a/data/nodes/mailprivate-vm.apache.org.yaml
+++ b/data/nodes/mailprivate-vm.apache.org.yaml
@@ -96,6 +96,7 @@ vhosts_asf::vhosts::vhosts:
             AuthLDAPurl "ldaps://ldap-eu-ro.apache.org/ou=people,dc=apache,dc=org?uid"
             <RequireAll>
               AuthLDAPGroupAttribute owner
+              AuthLDAPGroupAttributeIsDN On
               AuthLDAPRemoteUserIsDN On
               Require ldap-group cn=$cn,ou=project,ou=groups,dc=apache,dc=org
             </RequireAll>


### PR DESCRIPTION
Unfortunately PMC access stopped working when I extracted the shared attributes.
I'm hoping that explicitly setting AuthLDAPGroupAttributeIsDN will fix this.