### PR TITLE
archetypes with an s goes ro INFRA-16087

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -1367,7 +1367,7 @@ buildbot = rw
 [/maven]
 @maven = rw
 
-[/maven/archetype]
+[/maven/(archetype|archetypes)]
 * = r
 
 [/maven/core-integration-testing]


### PR DESCRIPTION
@gmcdonald I don't think you can use parentheses in the pathname like that.