### PR TITLE
Various fixes to mail-archives init.pp

### DIFF
--- a/modules/mail_archives/manifests/init.pp
+++ b/modules/mail_archives/manifests/init.pp
@@ -237,7 +237,7 @@ class mail_archives (
       user        => $username,
       minute      => '05',
       hour        => '*/4',
-      command     => "/home/modmbox/scripts/site-sitemap.py '/x1/mail-archives.apache.org/mod_mbox/sitemap.%d.xml'",
+      command     => "/home/${username}/scripts/site-sitemap.py '/x1/mail-archives.apache.org/mod_mbox/sitemap.%d.xml'",
       environment => [
         'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
         'SHELL=/bin/sh'

--- a/modules/mail_archives/manifests/init.pp
+++ b/modules/mail_archives/manifests/init.pp
@@ -129,7 +129,7 @@ class mail_archives (
 
 # symlink mod_mbox for existing scripts
 
-    '/x1/mail-archives/mod_mbox':
+    "${install_dir}/mod_mbox":
     ensure => link,
     target => "${archives_www}/mod_mbox";
 
@@ -237,7 +237,7 @@ class mail_archives (
       user        => $username,
       minute      => '05',
       hour        => '*/4',
-      command     => "/home/${username}/scripts/site-sitemap.py '/x1/mail-archives.apache.org/mod_mbox/sitemap.%d.xml'",
+      command     => "/home/${username}/scripts/site-sitemap.py '${archives_www}/mod_mbox/sitemap.%d.xml'",
       environment => [
         'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
         'SHELL=/bin/sh'

--- a/modules/mail_archives/manifests/init.pp
+++ b/modules/mail_archives/manifests/init.pp
@@ -223,6 +223,7 @@ class mail_archives (
       require     => User[$username];
 
     'site-index':
+      # N.B. update-index also creates the index file
       user        => $username,
       minute      => '51',
       hour        => '*/4',

--- a/modules/mail_archives/manifests/init.pp
+++ b/modules/mail_archives/manifests/init.pp
@@ -237,7 +237,7 @@ class mail_archives (
       user        => $username,
       minute      => '05',
       hour        => '*/4',
-      command     => "/home/${username}/scripts/site-sitemap.py '${archives_www}/mod_mbox/sitemap.%d.xml'",
+      command     => "/home/${username}/scripts/site-sitemap.py '${archives_www}/mod_mbox/sitemap.\%d.xml'", # cron treats % as NL
       environment => [
         'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
         'SHELL=/bin/sh'

--- a/modules/mail_archives/manifests/init.pp
+++ b/modules/mail_archives/manifests/init.pp
@@ -9,7 +9,16 @@ class mail_archives (
   # override below in yaml
   $parent_dir,
 
-  $required_packages = ['apache2-dev' , 'autotools-dev' , 'autoconf' , 'libapr1' , 'libapr1-dev' , 'libaprutil1' , 'libaprutil1-dev' , 'scons'], # lint:ignore:140chars
+  $required_packages = [
+    'apache2-dev',
+    'autotools-dev',
+    'autoconf',
+    'libapr1',
+    'libapr1-dev',
+    'libaprutil1',
+    'libaprutil1-dev',
+    'scons'
+  ],
 ){
 
 # install required packages:
@@ -196,7 +205,10 @@ class mail_archives (
       minute      => '01',
       hour        => '*/4',
       command     => "/home/${username}/scripts/mbox-raw-rsync.sh",
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/sh", # lint:ignore:double_quoted_strings
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/sh'
+      ],
       require     => User[$username];
 
     'create-archive-list':
@@ -204,7 +216,10 @@ class mail_archives (
       minute      => '14',
       hour        => '*/4',
       command     => "/home/${username}/scripts/create-archive-list /home/${username}/archives/raw > /home/${username}/archives/mbox-archives.list", # lint:ignore:140chars
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/zsh", # lint:ignore:double_quoted_strings, lint:ignore:140chars
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/zsh'
+      ],
       require     => User[$username];
 
     'site-index':
@@ -212,7 +227,10 @@ class mail_archives (
       minute      => '51',
       hour        => '*/4',
       command     => "/home/${username}/scripts/site-index.py > ${archives_www}/mod_mbox/index.html",
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/sh", # lint:ignore:double_quoted_strings
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/sh'
+      ],
       require     => User[$username];
 
     'generate-sitemap':
@@ -220,14 +238,20 @@ class mail_archives (
       minute      => '05',
       hour        => '*/4',
       command     => "/home/modmbox/scripts/site-sitemap.py '/x1/mail-archives.apache.org/mod_mbox/sitemap.%d.xml'",
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/sh", # lint:ignore:double_quoted_strings
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/sh'
+      ],
       require     => User[$username];
 
     'update-index':
       user        => $username,
       minute      => '27',
       command     => "/home/${username}/scripts/setlock.pl /home/${username}/.update-lockfile /home/${username}/scripts/update-index",
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/zsh", # lint:ignore:double_quoted_strings, lint:ignore:140chars
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/zsh'
+      ],
       require     => User[$username];
 
     'update-index-monthly':
@@ -236,7 +260,10 @@ class mail_archives (
       hour        => '14',
       monthday    => '1',
       command     => "/home/${username}/scripts/setlock.pl /home/${username}/.update-lockfile /home/${username}/scripts/update-index-monthly", # lint:ignore:140chars
-      environment => "PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\nSHELL=/bin/zsh", # lint:ignore:double_quoted_strings, lint:ignore:140chars
+      environment => [
+        'PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
+        'SHELL=/bin/zsh'
+      ],
       require     => User[$username];
 
   }


### PR DESCRIPTION
There is one fix: crontab treats % as a new-line, which means that the job is not getting the correct parameters.
This can be seen from the Kibana entries which show a truncated parameter for the generate-sitemap job. It's not clear whether any errors are generated by the script

The other changes are cosmetic:
- consistent variable usage
- use arrays for cron environment