### PR TITLE
+= output filter for atticked TLPs

### DIFF
--- a/data/nodes/themis.apache.org.yaml
+++ b/data/nodes/themis.apache.org.yaml
@@ -2385,6 +2385,11 @@ vhosts_asf::vhosts::vhosts:
       RewriteCond %%{}{HTTP_HOST} ^([^.]+)\.us.ipv4.apache.org$
       RewriteRule ^/mail/(.*)$ http://mail-archives.apache.org/mod_mbox/%1-$1 [R=301,L]
 
+      LuaOutputFilter attic "/var/www/attic.apache.org/scripts/attic_filter.lua" output_filter
+      <If "-d '/var/www/attic.apache.org/flagged/%{HTTP_HOST}'">
+        AddOutputFilter attic html
+      </If>
+
 
   tlp-ssl:
     priority: 99
@@ -2479,6 +2484,11 @@ vhosts_asf::vhosts::vhosts:
       #/mail/* -> mail-archives.a.o/mod_mbox/tlp-list
       RewriteCond %%{}{HTTP_HOST} ^([^.]+)\.us.ipv4.apache.org$
       RewriteRule ^/mail/(.*)$ https://mail-archives.apache.org/mod_mbox/%1-$1 [R=301,L]
+
+      LuaOutputFilter attic "/var/www/attic.apache.org/scripts/attic_filter.lua" output_filter
+      <If "-d '/var/www/attic.apache.org/flagged/%{HTTP_HOST}'">
+        AddOutputFilter attic html
+      </If>
 
   tomee:
     vhost_name: '*'

--- a/data/nodes/tlp-eu-west.apache.org.yaml
+++ b/data/nodes/tlp-eu-west.apache.org.yaml
@@ -2384,6 +2384,11 @@ vhosts_asf::vhosts::vhosts:
       RewriteCond %%{}{HTTP_HOST} ^([^.]+)\.us.ipv4.apache.org$
       RewriteRule ^/mail/(.*)$ http://mail-archives.apache.org/mod_mbox/%1-$1 [R=301,L]
 
+      LuaOutputFilter attic "/var/www/attic.apache.org/scripts/attic_filter.lua" output_filter
+      <If "-d '/var/www/attic.apache.org/flagged/%{HTTP_HOST}'">
+        AddOutputFilter attic html
+      </If>
+
 
   tlp-ssl:
     priority: 99
@@ -2478,6 +2483,11 @@ vhosts_asf::vhosts::vhosts:
       #/mail/* -> mail-archives.a.o/mod_mbox/tlp-list
       RewriteCond %%{}{HTTP_HOST} ^([^.]+)\.us.ipv4.apache.org$
       RewriteRule ^/mail/(.*)$ https://mail-archives.apache.org/mod_mbox/%1-$1 [R=301,L]
+
+      LuaOutputFilter attic "/var/www/attic.apache.org/scripts/attic_filter.lua" output_filter
+      <If "-d '/var/www/attic.apache.org/flagged/%{HTTP_HOST}'">
+        AddOutputFilter attic html
+      </If>
 
   tomee:
     vhost_name: '*'


### PR DESCRIPTION
This change only affects oltu.apache.org [recently retired] ;
because (only) /www/attic.apache.org/flagged/oltu.apache.org/ exists.

To test, visit http://oltu.apache.org/
