### PR TITLE
Retire Oltu. In addition to the patch provided on INFRA-16309 I also removed the oltu ldap group entries for asf and pit auth files.

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -289,8 +289,6 @@ ofbiz={ldap:cn=ofbiz,ou=project,ou=groups,dc=apache,dc=org;attr=member}
 ofbiz-pmc={reuse:pit-authorization:ofbiz-pmc}
 olingo={ldap:cn=olingo,ou=project,ou=groups,dc=apache,dc=org;attr=member}
 olingo-pmc={reuse:pit-authorization:olingo-pmc}
-oltu={ldap:cn=oltu,ou=project,ou=groups,dc=apache,dc=org;attr=member}
-oltu-pmc={reuse:pit-authorization:oltu-pmc}
 oodt={ldap:cn=oodt,ou=project,ou=groups,dc=apache,dc=org;attr=member}
 oodt-pmc={reuse:pit-authorization:oodt-pmc}
 oozie={ldap:cn=oozie,ou=project,ou=groups,dc=apache,dc=org;attr=member}
@@ -1488,7 +1486,7 @@ svn-site-role = rw
 @olingo = rw
 
 [/oltu]
-@oltu = rw
+@attic-pmc = rw
 
 [/onami]
 @attic-pmc = rw

--- a/modules/subversion_server/files/authorization/asf-mailer.conf
+++ b/modules/subversion_server/files/authorization/asf-mailer.conf
@@ -214,7 +214,7 @@ to_addr = notifications@ant.apache.org
 
 # Attic
 [/attic]
-for_paths = (attic|abdera|ace|avalon|beehive|click|esme|etch|excalibur|harmony|hivemind|ibatis|jakarta|shale|lenya|whirr|deltacloud|directmemory|xmlbeans|stdcxx|shindig|rave|onami|wookie|mrunit|tuscany|continuum|devicemap|stratos|wink|xml)/
+for_paths = (attic|abdera|ace|avalon|beehive|click|esme|etch|excalibur|harmony|hivemind|ibatis|jakarta|shale|lenya|whirr|deltacloud|directmemory|xmlbeans|stdcxx|shindig|rave|onami|wookie|mrunit|tuscany|continuum|devicemap|oltu|stratos|wink|xml)/
 to_addr = general@attic.apache.org
 
 # --------------------------------------------------------------------------

--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -209,8 +209,6 @@ ofbiz={reuse:asf-authorization:ofbiz}
 ofbiz-pmc={ldap:cn=ofbiz,ou=project,ou=groups,dc=apache,dc=org;attr=owner}
 olingo={reuse:asf-authorization:olingo}
 olingo-pmc={ldap:cn=olingo,ou=project,ou=groups,dc=apache,dc=org;attr=owner}
-oltu={reuse:asf-authorization:oltu}
-oltu-pmc={ldap:cn=oltu,ou=project,ou=groups,dc=apache,dc=org;attr=owner}
 oodt={reuse:asf-authorization:oodt}
 oodt-pmc={ldap:cn=oodt,ou=project,ou=groups,dc=apache,dc=org;attr=owner}
 oozie={reuse:asf-authorization:oozie}


### PR DESCRIPTION
Retire Oltu. In addition to the patch provided on INFRA-16309 I also removed the oltu ldap group entries for asf and pit auth files.