### PR TITLE
Oops - accidentally dropped a section instead of moving it

### DIFF
--- a/data/nodes/tlp-eu-west.apache.org.yaml
+++ b/data/nodes/tlp-eu-west.apache.org.yaml
@@ -25,6 +25,10 @@ classes:
   - datadog_agent::integrations::apache
   - datadog_asf::integrations::network
   - loggy
+  - rootbin_asf
+  - rsync
+  - rsync::server
+  - rsync_mirror
   - ssl::name::wildcard_apache_org
   - ssl::name::apachecon_com
   - ssl::name::archive_apachecon_com


### PR DESCRIPTION
Sorry: I intended to move this section into the correct place alphabetically, but it got dropped instead.