### PR TITLE
alter cron jobs for authz generation

### DIFF
--- a/modules/subversion_server/manifests/init.pp
+++ b/modules/subversion_server/manifests/init.pp
@@ -649,15 +649,16 @@ class subversion_server (
       hour    => '*',
       user    => 'www-data',
       command => '/x1/svn/scripts/authorization/gen_asf-authorization.pl template_commit > /dev/null';
+    'authz-rebuild-new':
+      minute  => '*/3',
+      hour    => '*',
+      user    => 'www-data',
+      command => '/x1/svn/scripts/authorization/gen.py';
     'generate-dist-auth':
       minute  => '15',
       hour    => '*',
       user    => 'www-data',
       command => 'cd /x1/svn/authorization/templates ; ./generate-dist-authorization > asf-dist-authorization.t && mv asf-dist-authorization.t ../asf-dist-authorization'; # lint:ignore:140chars
-    'generate-asf-auth':
-      minute  => '*/3',
-      hour    => '*',
-      command => '/x1/svn/scripts/authorization/gen_asf-authorization.pl ldap_change > /dev/null';
     'svn-create-dump':
       monthday => '1',
       minute   => '15',


### PR DESCRIPTION
* add cron job for the new python-based authz generation
* remove the "ldap_change" authz step, as it is redundant with the
  other generation step

note: the old perl-based "template_commit" generate is still running
and creates proper files (the new py step creates *.alt for now)