### PR TITLE
mysql rsync

### DIFF
--- a/data/nodes/mysql1-ec2-va.apache.org.yaml
+++ b/data/nodes/mysql1-ec2-va.apache.org.yaml
@@ -3,7 +3,8 @@ classes:
   - datadog_agent::integrations::mysql
   - mysql_asf::backup
   - mysql::server
-  - zmanda_asf::client
+
+mysql_asf::backup::rsync_offsite: true
 
 puppet_asf::daemon_opts: '--verbose --debug'
 

--- a/modules/mysql_asf/manifests/backup.pp
+++ b/modules/mysql_asf/manifests/backup.pp
@@ -1,12 +1,15 @@
 #/etc/puppet/modules/mysql_asf/manifests/backup.pp
 
+include stunnel_asf
+
 class mysql_asf::backup (
-  $script_path = '/root',
-  $script_name = 'dbsave_mysql.sh',
-  $hour        = 03,
-  $minute      = 45,
-  $dumproot    = '/x1/db_dump/mysql',
-  $age         = '5d',
+  $script_path   = '/root',
+  $script_name   = 'dbsave_mysql.sh',
+  $hour          = 03,
+  $minute        = 45,
+  $dumproot      = '/x1/db_dump/mysql',
+  $age           = '5d',
+  $rsync_offsite = 'false', # copy to bai if true, requires setup
 ) {
 
   require mysql::server

--- a/modules/mysql_asf/templates/dbsave_mysql.sh.erb
+++ b/modules/mysql_asf/templates/dbsave_mysql.sh.erb
@@ -19,6 +19,7 @@ PASS=$(cd /root/ ; cat .my.cnf | grep -i -m 1 pa | sed 's/password=//g' | sed "s
 PORT='3306'
 ALLDBS=`echo "SHOW DATABASES;" | ${MYSQL} -u ${DBUSER} | egrep -v "^(Database|information_schema|performance_schema)" 2>&1`;
 DBLISTFILE="/tmp/mysql.dump.list"
+RSYNC_OFFSITE="<%= @rsync_offsite %>"
 
 
 ## ------------------------
@@ -108,7 +109,9 @@ for DBNAME in `cat "${DBLISTFILE}"` ; do
   create_dumpdir;
   backup_db
   sleep 5
-#  rsync_offsite
+  if [ $RSYNC_OFFSITE == 'true' ] ; then
+    rsync_offsite
+  fi
   sleep 5;
 done
 


### PR DESCRIPTION
add a flaggable ability to push mysql db dumps offsite to bai via rsync.
add stunnel_asf as a dependency to mysql_asf::backup. This shouldn't
affect machines that don't need it, but is necessary to make offsite
backups use only a single flag. nb: this will also require further
commits/changes to enable the backup on bai and eyaml to add the rsync
passwords.