### PR TITLE
Moving datadog_agent to github.com/apache/puppet_datadog_agent in order to make changes to DD agent 1.7.0 which is EOL.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -37,7 +37,7 @@ mod 'datacat',
 
 
 mod 'datadog_agent',
-  :git => 'https://github.com/DataDog/puppet-datadog-agent',
+  :git => 'https://github.com/apache/puppet-datadog-agent',
   :tag => '1.7.0'
 
 


### PR DESCRIPTION
Moving datadog_agent to github.com/apache/puppet_datadog_agent in order to make changes to DD agent 1.7.0 which is EOL.