### PR TITLE
Zeppelin approach the 1GB limit for then bin-all file

### DIFF
--- a/data/nodes/svn01-us-west.apache.org.yaml
+++ b/data/nodes/svn01-us-west.apache.org.yaml
@@ -268,7 +268,7 @@ vhosts_asf::vhosts::vhosts:
         LimitRequestBody 350000000
       </LocationMatch>
       <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/zeppelin/>
-        LimitRequestBody 950000000
+        LimitRequestBody 1000000000
       </LocationMatch>
       <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/phoenix/>
         LimitRequestBody 600000000
@@ -293,9 +293,6 @@ vhosts_asf::vhosts::vhosts:
       </LocationMatch>
       <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/pig/>
         LimitRequestBody 350000000
-      </LocationMatch>
-      <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/zeppelin/>
-        LimitRequestBody 100000000000
       </LocationMatch>
       #<LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/$PMC/>
       #  LimitRequestBody $LIMIT

--- a/data/nodes/svn01-us-west.apache.org.yaml
+++ b/data/nodes/svn01-us-west.apache.org.yaml
@@ -294,6 +294,9 @@ vhosts_asf::vhosts::vhosts:
       <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/pig/>
         LimitRequestBody 350000000
       </LocationMatch>
+      <LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/zeppelin/>
+        LimitRequestBody 100000000000
+      </LocationMatch>
       #<LocationMatch /repos/dist/!svn/(txr|wrk)/[^/]+/dev/$PMC/>
       #  LimitRequestBody $LIMIT
       #</LocationMatch>


### PR DESCRIPTION
Zeppelin approach the 1GB limit for then bin-all file