### PR TITLE
Add dot-forward package, replaces qmail-contrib as supplied by fbsd

### DIFF
--- a/modules/qmail_asf/manifests/init.pp
+++ b/modules/qmail_asf/manifests/init.pp
@@ -16,7 +16,7 @@ class qmail_asf (
   $stats_url = '',
   $mm_auth = '',
 
-  $required_packages             = ['qmail' , 'daemontools' , 'ucspi-tcp' , 'rbldnsd' , 'djbdns' , 'dnscache-run' , 'dnsmasq' , 'clamav' , 'clamav-freshclam' , 'qpsmtpd'],
+  $required_packages             = ['qmail' , 'dot-forward' , 'daemontools' , 'ucspi-tcp' , 'rbldnsd' , 'djbdns' , 'dnscache-run' , 'dnsmasq' , 'clamav' , 'clamav-freshclam' , 'qpsmtpd'],
 ){
 
 # install required packages:


### PR DESCRIPTION
Add dot-forward package, replaces qmail-contrib as supplied by fbsd