### PR TITLE
Treat www-eu and www-us equally

### DIFF
--- a/data/roles/tlpserver.yaml
+++ b/data/roles/tlpserver.yaml
@@ -415,6 +415,7 @@ vhosts_asf::vhosts::vhosts:
       - 'apachegroup.org'
       - 'www.apachegroup.org'
       - 'www.*.apache.org'
+      - 'www-eu.apache.org'
       - 'www-us.apache.org'
     directories:
       -
@@ -525,6 +526,7 @@ vhosts_asf::vhosts::vhosts:
       - 'apachegroup.org'
       - 'www.apachegroup.org'
       - 'www.*.apache.org'
+      - 'www-eu.apache.org'
       - 'www-us.apache.org'
     directories:
       -


### PR DESCRIPTION
AFAICT it does not make sense to only support www-us for the (shared) tlpserver.

Applying this should fix the broken www-eu.a.o URLs.