### PR TITLE
Adding logrotate config for Apache2 on netbeans-vm.apache.org

### DIFF
--- a/data/nodes/netbeans-vm.apache.org.yaml
+++ b/data/nodes/netbeans-vm.apache.org.yaml
@@ -13,6 +13,21 @@ apache::timeout:            600
 apache::mpm_module:         'prefork'
 apache::purge_configs:      false
 
+logrotate::rule:
+  apache2:
+    ensure: 'present'
+    path: '/var/log/apache2*.log'
+    compress: true
+    delaycompress: true
+    ifempty: true
+    missingok: true
+    rotate: 365
+    rotate_every: 'day'
+    create: true
+    create_mode: 0644
+    dateext: true
+    dateformat: '_%Y%m%d'
+
 letsencrypt::email: 'root@apache.org'
 letsencrypt::manage_dependencies: false
 letsencrypt::certonly:


### PR DESCRIPTION
Hello,
for netbeans-vm.apache.org we need Apache2 logfiles to rotate daily so we can do some ad-hoc processing and analysis of daily logs.