### PR TITLE
setting svn repo for Turbine Maven Archetypes to read only INFRA-16437

### DIFF
--- a/modules/subversion_server/files/authorization/asf-authorization-template
+++ b/modules/subversion_server/files/authorization/asf-authorization-template
@@ -1853,6 +1853,10 @@ svn-role = rw
 [/turbine]
 @turbine = rw
 
+#moved to gitbox INFRA-16437
+[/turbine/maven/archetypes]
+* = r
+
 [/tuscany]
 @attic-pmc = rw
 


### PR DESCRIPTION
setting svn repo for Turbine Maven Archetypes to read only INFRA-16437