### PR TITLE
Update drat-vm.apache.org.yaml

### DIFF
--- a/data/nodes/drat-vm.apache.org.yaml
+++ b/data/nodes/drat-vm.apache.org.yaml
@@ -66,8 +66,6 @@ vhosts_asf::vhosts::vhosts:
         path: '/.well-known/'
         url: '!'
       -
-        path: '/asfgit'
-        url: 'http://localhost:8080/viz'
-      -
         path: '/demo'
-        url: 'http://localhost:8080/proteus'
+        url: 'http://localhost:8080/proteus-new'
+


### PR DESCRIPTION
Please point this path to our new DRAT proteus app - we are gearing up to release a 1.0-RC1 candidate and this will be the updated path.