### PR TITLE
Typo - align with existing paths

### DIFF
--- a/data/nodes/whimsy-vm4.apache.org.yaml
+++ b/data/nodes/whimsy-vm4.apache.org.yaml
@@ -223,7 +223,7 @@ vhosts_whimsy::vhosts::vhosts:
       </Directory>
 
       # WHIMSY-199
-      <Directory /srv/whimsy/www/board/minutes>
+      <Directory /x1/srv/whimsy/www/board/minutes>
         AllowOverride FileInfo
       </Directory>
 


### PR DESCRIPTION
Oops - wrong pathname