### PR TITLE
change jenkins cleanup script to run daily

### DIFF
--- a/modules/jenkins_asf/manifests/init.pp
+++ b/modules/jenkins_asf/manifests/init.pp
@@ -223,11 +223,10 @@ cron {
       command  => "/x1/${username}/jenkins-home/delete-workspace-disabled-jobs.sh",
       require  => User[$username];
 
-'trim-workspaces-all-jobs-weekly':
+'trim-workspaces-all-jobs-daily':
       user    => $username,
       minute  => '19',
       hour    => '04',
-      weekday => '6',
       command => "/x1/${username}/jenkins-home/trim-workspace-all-jobs.sh",
       require => User[$username];
 }


### PR DESCRIPTION
due to multiple nodes (still with 360gb disks) alerting, I think running this daily would be better, since we're only looking for 31 day retention anyways