### PR TITLE
Ensure log dir exists before rm cleanup

### DIFF
--- a/modules/cwiki_asf/templates/cleanup-tomcat-logs.sh.erb
+++ b/modules/cwiki_asf/templates/cleanup-tomcat-logs.sh.erb
@@ -3,15 +3,19 @@
 CATALINA_LOG_DIR=<%= @current_dir %>/logs
 X1_SPACE=`df -H | grep x1 | awk '{print $5}' | cut -d'%' -f1`
 
-cd $CATALINA_LOG_DIR
-
-if [ $X1_SPACE -gt 70 ];then
-  find . -mtime +7 -exec rm {} \;
-  X1_SPACE=`df -H | grep x1 | awk '{print $5}' | cut -d'%' -f1`
+if [ -d "$CATALINA_LOG_DIR" ];then
+  cd $CATALINA_LOG_DIR
+  
   if [ $X1_SPACE -gt 70 ];then
-    find . -mtime +3 -exec rm {} \;
-fi
-else
-  find . -mtime +14 -exec rm {} \;
-fi
+    find . -mtime +7 -exec rm {} \;
+    X1_SPACE=`df -H | grep x1 | awk '{print $5}' | cut -d'%' -f1`
+    if [ $X1_SPACE -gt 70 ];then
+      find . -mtime +3 -exec rm {} \;
+    fi
+  else
+    find . -mtime +14 -exec rm {} \;
+  fi
 
+else
+  echo "Log dir does not exist, so not running the script."
+fi


### PR DESCRIPTION
Lets make sure the logs dir we are changing into actually exists, otherwise 'find .' along with 'exec rm' could have unintended side effects.