### PR TITLE
extend jenkins role regex to default GCE names for beam nodes

### DIFF
--- a/modules/customfact/lib/facter/customfact.rb
+++ b/modules/customfact/lib/facter/customfact.rb
@@ -133,7 +133,7 @@ Facter.add("noderole") do
       "jenkins"
     elsif hostname.include? "jenkins-win" # include all Windows nodes
       "jenkins-win"
-    elsif hostname.include?("jenkins-beam") || hostname.include?("jenkins-cassandra") || hostname.include?("jenkins-beam")
+    elsif hostname.include?("jenkins-beam") || hostname.include?("jenkins-cassandra") || hostname.include?("beam-jenkins")
       "jenkins-external"
     elsif hostname =~ /openwhisk-vm\d-he-de/ # OpenWhisk Jenkins boxes
       "jenkins"

--- a/modules/customfact/lib/facter/customfact.rb
+++ b/modules/customfact/lib/facter/customfact.rb
@@ -133,7 +133,7 @@ Facter.add("noderole") do
       "jenkins"
     elsif hostname.include? "jenkins-win" # include all Windows nodes
       "jenkins-win"
-    elsif hostname.include?("jenkins-beam") || hostname.include?("jenkins-cassandra")
+    elsif hostname.include?("jenkins-beam") || hostname.include?("jenkins-cassandra") || hostname.include?("jenkins-beam")
       "jenkins-external"
     elsif hostname =~ /openwhisk-vm\d-he-de/ # OpenWhisk Jenkins boxes
       "jenkins"


### PR DESCRIPTION
should solve problem with GCE beam nodes not preserving hostnames