### PR TITLE
[BEAM-4499] Update Beam website publising

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -45,7 +45,8 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/asterixdb.apache.org:          asterixdb-site
 /www/atlas.apache.org:              atlas-website
 /www/bahir.apache.org:              bahir-website
-/www/beam.apache.org:               $gitbox/beam-site
+/www/beam.apache.org:               $gitbox/beam
+/www/beam.apache.org/content/releases: $gitbox/beam-site:release-docs
 /www/bookkeeper.apache.org:         $gitbox/bookkeeper
 /www/bookkeeper.apache.org/content/distributedlog:  $gitbox/distributedlog
 /www/carbondata.apache.org:         carbondata-site


### PR DESCRIPTION
Beam is updating its infrastructure for generating and publishing
website content. Motivation and details at: https://s.apache.org/beam-site-automation

Website sources are now hosted at: https://github.com/apache/beam/tree/master/website
Website generated HTML is now hosted at: https://github.com/apache/beam/tree/asf-site
Release-based javadocs and pydocs are now hosted at: https://github.com/apache/beam-site/tree/release-docs