### PR TITLE
hermes-vm

### DIFF
--- a/modules/postfix_server_asf/manifests/init.pp
+++ b/modules/postfix_server_asf/manifests/init.pp
@@ -9,7 +9,7 @@
 
 class postfix_server_asf {
 
-  if $::hostname != 'hermes-vm' {
+  if $::hostname ~= /hermes-vm/ {
     include postfix::server
   }
 


### PR DESCRIPTION
switch to using a pattern match for hermes-vm
this allows for vagrant testing as long as the generated vagrant
hostname contains the string 'hermes-vm'