### PR TITLE
Change camel-website checkout directory path

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -50,7 +50,7 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/bookkeeper.apache.org:         $gitbox/bookkeeper
 /www/bookkeeper.apache.org/content/distributedlog:  $gitbox/distributedlog
 /www/carbondata.apache.org:         carbondata-site
-/www/camel.apache.org/staging:      $gitbox/camel-website
+/www/camel.apache.org/content/staging: $gitbox/camel-website
 /www/cayenne.apache.org:            cayenne-website
 /www/cloudstack.apache.org:         $gitbox/cloudstack-www
 /www/couchdb.apache.org:            couchdb-www


### PR DESCRIPTION
Makes the checkout directory for the camel-website.git:asf-site branch
be `/www/camel.apache.org/content/staging` as the current site has a
`/content` which is matched by rewrite rules. As suggested by Daniel
Gruno[1]

[1] https://issues.apache.org/jira/browse/INFRA-15969?focusedCommentId=16668569#comment-16668569