### PR TITLE
removing gradle 3.5, 4.3.1, and 4.4.1. Adding 4.6, 4.7, 4.8.1, 4.9, 4.10, and 4.10.2 to Jenkins and Buildbot slaves

### DIFF
--- a/modules/build_slaves/manifests/jenkins.pp
+++ b/modules/build_slaves/manifests/jenkins.pp
@@ -51,11 +51,13 @@ class build_slaves::jenkins (
     'jbake-2.5.1',
     'jbake-2.6.1',
     ],
+  #latest gradle version gets installed on line 229
   $gradle_versions = [
-    '3.5',
-    '4.3.1',
-    '4.4.1',
+    '4.6',
+    '4.7',
     '4.8.1',
+    '4.9',
+    '4.10',
     ],
   # $maven_old = ['apache-maven-3.0.4','apache-maven-3.2.1'],
   $maven = [
@@ -224,7 +226,7 @@ class build_slaves::jenkins (
   apt::ppa { 'ppa:cwchien/gradle':
     ensure => present,
   }
-  -> package { 'gradle': # this installs the latest version which is 4 right now
+  -> package { 'gradle': # this installs the latest version
     ensure => latest,
   }
 
@@ -563,19 +565,10 @@ class build_slaves::jenkins (
   }
 
 
-  # make gradle symlinks 4.3 is the latest
-  build_slaves::symlink_gradle { $gradle_versions: }
-  file { "/home/${build_slaves::username}/tools/gradle/4.3":
+  # make latest gradle symlink
+  file { "/home/${build_slaves::username}/tools/gradle/latest":
     ensure => link,
-    target => '/usr/lib/gradle/4.3.1',
-  }
-  file { "/home/${build_slaves::username}/tools/gradle/4.4":
-    ensure => link,
-    target => '/usr/lib/gradle/4.4.1',
-  }
-  file { "/home/${build_slaves::username}/tools/gradle/4.8":
-    ensure => link,
-    target => '/usr/lib/gradle/4.8.1',
+    target => '/usr/lib/gradle/default',
   }
 
   cron {

--- a/modules/buildbot_slave/manifests/init.pp
+++ b/modules/buildbot_slave/manifests/init.pp
@@ -9,7 +9,7 @@ class buildbot_slave (
   $user_present      = 'present',
   $username          = 'buildslave',
   $service_name      = 'buildslave',
-  $gradle_versions   = ['3.5', '4.3', '4.3.1'],
+  $gradle_versions   = ['4.6', '4.7', '4.8.1','4.9','4.10','4.10.2'],
 
   # override below in eyaml
 


### PR DESCRIPTION
removing gradle 3.5, 4.3.1, and 4.4.1. Adding 4.6, 4.7, 4.8.1, 4.9, 4.10, and 4.10.2 to Jenkins and Buildbot slaves