### PR TITLE
certbot

### DIFF
--- a/data/ubuntu/ubuntu_1604.yaml
+++ b/data/ubuntu/ubuntu_1604.yaml
@@ -176,6 +176,17 @@ apt::sources:
     include:
       deb: true
       src: false
+  'certbot':
+    ensure: 'present'
+    location: 'http://ppa.launchpad.net/letsencrypt/letsencrypt/ubuntu'
+    release: 'xenial'
+    repos: 'main'
+    key:
+        id: 'C871CF14D6A1C3D7D5E784C2BA0A20FC7B4DD417'
+        server: 'hkp://keyserver.ubuntu.com:80'
+    include:
+        src: false
+        deb: true
 
 apt::force:
   'orthrus':


### PR DESCRIPTION
add official ppa for managing up-to-date versions of certbot