### PR TITLE
Old LDAP no longer useful; fix bug for empty owner

### DIFF
--- a/modules/subversion_server/files/authorization/generate-dist-authorization
+++ b/modules/subversion_server/files/authorization/generate-dist-authorization
@@ -3,16 +3,12 @@
 # various constants
 SVNADMINS="gmcdonald,humbedooh,cml,christ"
 
-UNIXBASE="ou=groups,dc=apache,dc=org"
-BASE="ou=pmc,ou=committees,ou=groups,dc=apache,dc=org"
 PBASE="ou=project,ou=groups,dc=apache,dc=org"
 LDAPSEARCH="ldapsearch"
 
 XARGS="xargs"
 SED="sed"
 TR="tr"
-
-pmcs=`$LDAPSEARCH -x -LLL -b $BASE 'cn=*' cn | $SED -ne 's/^cn: //p' | $SED -e '/^incubator$/d' | $SED -e '/^tac$/d' | sort`
 
 projects=`$LDAPSEARCH -x -LLL -b $PBASE 'cn=*' cn | $SED -ne 's/^cn: //p' | $SED -e '/^incubator$/d' | $SED -e '/^tac$/d' | sort`
 
@@ -40,26 +36,19 @@ henkp = rw
 svnadmins=$SVNADMINS
 EOF
 
-# fill in old style [groups]
-for pmc in $pmcs; do
-  printf "%s=" "$pmc"
-  $LDAPSEARCH -x -LLL -b "cn=$pmc,$UNIXBASE" 'cn=*' memberUid | $SED -ne 's/^memberUid: //p' | $XARGS | $SED -e 's/ /,/g'
-  printf "%s-pmc=" "$pmc"
-  $LDAPSEARCH -x -LLL -b "cn=$pmc,$BASE" 'cn=*' member | $SED -ne 's/^member: //p' | cut -d, -f1 | cut -d= -f2 | $XARGS | $SED -e 's/ /,/g'
-done
 
 # fill in new style [groups] 
 for pmc in $projects incubator; do
-  printf "%s=" "$pmc"   
-  $LDAPSEARCH -x -LLL -b "cn=$pmc,$PBASE" 'cn=*' member | $SED -ne 's/^member: //p' | cut -d, -f1 | cut -d= -f2 | $XARGS | $SED -e 's/ /,/g'
-  printf "%s-pmc=" "$pmc"  
-  $LDAPSEARCH -x -LLL -b "cn=$pmc,$PBASE" 'cn=*' owner | $SED -ne 's/^owner: //p' | cut -d, -f1 | cut -d= -f2 | $XARGS | $SED -e 's/ /,/g'
+  mem=$($LDAPSEARCH -x -LLL -b "cn=$pmc,$PBASE" 'cn=*' member | $SED -ne 's/^member: //p' | cut -d, -f1 | cut -d= -f2 | sort | $XARGS | $SED -e 's/ /,/g')
+  echo "$pmc=$mem"
+  own=$($LDAPSEARCH -x -LLL -b "cn=$pmc,$PBASE" 'cn=*' owner | $SED -ne 's/^owner: //p' | cut -d, -f1 | cut -d= -f2 | sort | $XARGS | $SED -e 's/ /,/g')
+  echo "${pmc}-pmc=$own"
 done
 
 echo
 
 # fill in per-PMC sections
-all_projects=`echo "$pmcs $projects" | $TR ' ' '\n' | sort | uniq | $XARGS`
+all_projects=`echo "$projects" | $TR ' ' '\n' | sort | uniq | $XARGS`
 for pmc in $all_projects; do
   echo
   echo "# $pmc"


### PR DESCRIPTION
The old LDAP groups are not needed any more.
In any case, the generated entries will be overridden by the new groups

Also the script does not handle empty member/owner groups properly - it fails to provide the trailing newline.
e.g. gearpump-pmc is empty and results in the following invalid output:

gearpump-pmc=geode=.....
geode-pmc=...

The geode auth only works at present because of the duplicates generated by the old-style groups.