### PR TITLE
nss-ldap

### DIFF
--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -223,6 +223,7 @@ access to dn.subtree="ou=people,dc=apache,dc=org"
   by dn="cn=idao-ro,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -237,6 +238,7 @@ access to dn.subtree="ou=people,dc=apache,dc=org"
   by dn="cn=idao-ro,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -247,6 +249,7 @@ access to dn.subtree="ou=people,dc=apache,dc=org"
   by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -259,6 +262,7 @@ access to dn.subtree="ou=hudson,ou=apps,ou=groups,dc=apache,dc=org"
   by dnattr=owner write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -269,6 +273,7 @@ access to dn.subtree="ou=groups,dc=apache,dc=org"
   by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -280,6 +285,7 @@ access to dn.subtree="ou=auth,ou=groups,dc=apache,dc=org"
   by dnattr=member write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -294,6 +300,7 @@ access to dn.subtree="ou=groups,dc=apache,dc=org"
   by dnattr=owner write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -304,6 +311,7 @@ access to dn.exact="cn=pmc-chairs,ou=groups,ou=services,dc=apache,dc=org"
   by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -313,6 +321,7 @@ access to dn.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org"
   by group.exact="cn=asf-secretary,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -323,6 +332,7 @@ access to dn.exact="cn=board,ou=groups,ou=services,dc=apache,dc=org"
   by group.exact="cn=board,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -332,6 +342,7 @@ access to dn.subtree="ou=sudoers,ou=groups,ou=services,dc=apache,dc=org"
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -343,6 +354,7 @@ access to dn.subtree="ou=services,dc=apache,dc=org"
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -354,6 +366,7 @@ access to dn.subtree="ou=sandbox,dc=apache,dc=org"
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" auth
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * auth
   by anonymous none
 
@@ -362,6 +375,7 @@ access to dn.subtree="ou=sandbox,dc=apache,dc=org"
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous auth
 
@@ -374,6 +388,7 @@ access to *
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
   by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_p6,ou=users,ou=services,dc=apache,dc=org" read
   by * read
   by anonymous none
 


### PR DESCRIPTION
add an extra ACL for a new nss_ldap account for binding puppet6 clients.