### PR TITLE
netbeans-vm.apache.org/bits.netbeans.org

### DIFF
--- a/data/nodes/netbeans-vm.apache.org.yaml
+++ b/data/nodes/netbeans-vm.apache.org.yaml
@@ -34,6 +34,7 @@ letsencrypt::certonly:
   netbeans:
     domains:
       - netbeans-vm.apache.org
+      - bits.netbeans.org
     plugin: webroot
     webroot_paths:
       - /var/www/html
@@ -117,3 +118,81 @@ vhosts_asf::vhosts::vhosts:
           Order allow,deny
           Allow from all
       </Directory>
+
+  bits-netbeans-org-ssl:
+    servername: 'bits.netbeans.org'
+    port: 443
+    ssl: true
+    ssl_cert: '/etc/letsencrypt/live/bits.netbeans.org/cert.pem'
+    ssl_key:  '/etc/letsencrypt/live/bits.netbeans.org/privkey.pem'
+    ssl_chain: '/etc/letsencrypt/live/bits.netbeans.org/chain.pem'
+    ssl_proxyengine: true
+    docroot:  '/var/www/bits.netbeans.org'
+    access_log_format: 'combined'
+    access_log_file: 'bits.netbeans.org.log'
+    error_log_file: 'bits.netbeans.org_error.log'
+    directories:
+      -
+        path: '/var/www/bits.netbeans.org'
+        options:
+          - 'FollowSymLinks'
+          - 'MultiViews'
+        allow_override:
+          - 'All'
+        order: 'allow,deny'
+        allow: 'from all'
+    custom_fragment: |
+
+      <Directory />
+        DirectoryIndex index.html
+        Options FollowSymLinks
+        AllowOverride None
+
+        # Enable rewrite engine
+        RewriteEngine On
+        # If the requested stuff is not a file ...
+        RewriteCond "%{REQUEST_FILENAME}" "!-f"
+        # ... nor a directory ...
+        RewriteCond "%{REQUEST_FILENAME}" "!-d"
+        # ... then redirect (302) to Oracle's server
+        RewriteRule "^/var/www/bits.netbeans.org/(.*)$" "http://137.254.56.27/%{REQUEST_URI}" [L,R=302]
+        # As a fallaback also redirect all 404 files
+        ErrorDocument 404 http://137.254.56.27%{REQUEST_URI}
+      </Directory>
+
+  bits-netbeans-org:
+    servername: 'bits.netbeans.org'
+    port: 80
+    docroot:  '/var/www/bits.netbeans.org'
+    access_log_format: 'combined'
+    access_log_file: 'bits.netbeans.org.log'
+    error_log_file: 'bits.netbeans.org_error.log'
+    directories:
+      -
+        path: '/var/www/bits.netbeans.org'
+        options:
+          - 'FollowSymLinks'
+          - 'MultiViews'
+        allow_override:
+          - 'All'
+        order: 'allow,deny'
+        allow: 'from all'
+    custom_fragment: |
+
+      <Directory />
+        DirectoryIndex index.html
+        Options FollowSymLinks
+        AllowOverride None
+
+        # Enable rewrite engine
+        RewriteEngine On
+        # If the requested stuff is not a file ...
+        RewriteCond "%{REQUEST_FILENAME}" "!-f"
+        # ... nor a directory ...
+        RewriteCond "%{REQUEST_FILENAME}" "!-d"
+        # ... then redirect (302) to Oracle's server
+        RewriteRule "^/var/www/bits.netbeans.org/(.*)$" "http://137.254.56.27/%{REQUEST_URI}" [L,R=302]
+        # As a fallaback also redirect all 404 files
+        ErrorDocument 404 http://137.254.56.27%{REQUEST_URI}
+      </Directory>
+


### PR DESCRIPTION
This is to set up the "bits.netbeans.org" virtual host in netbeans-vm.apache.org

NOTES:
- We already have a virtual host serving bits.netbeans.org:80 there. Hopefully this will be removed.
- We are now adding bits.netbeans.org virtual hosts at 80 and 443 (ssl). We want to use let's encrypt, so we addded the domains in the yaml like so:
```
letsencrypt::certonly:
  netbeans:
    domains:
      - netbeans-vm.apache.org
      - bits.netbeans.org
    plugin: webroot
    webroot_paths:
      - /var/www/html
    manage_cron: true
    cron_success_command: 'service apache2 reload'
```
Note that bits.netbeans.org webroot path is at `/var/www/bits.netbeans.org`, and not `/var/www/html`, shall we add a new entry under webroot_paths?

