### PR TITLE
Change back to jenkins-external. This is a revert of a commit october 1st 2018 where these were made internal. We have Beam folks with accounts on these boxes. As a side effect of that change also, kubectl which gets installed only on external nodes, was no longer being installed, but is required by Beam. See INFRA-17713

### DIFF
--- a/modules/customfact/lib/facter/customfact.rb
+++ b/modules/customfact/lib/facter/customfact.rb
@@ -143,8 +143,8 @@ Facter.add("noderole") do
       "jenkins"
     elsif hostname.include? "jenkins-win" # include all Windows nodes
       "jenkins-win"
-    elsif hostname.include?("jenkins-beam") || hostname.include?("beam-jenkins") # beam is infra mangaged
-      "jenkins"
+    elsif hostname.include?("jenkins-beam") || hostname.include?("beam-jenkins")
+      "jenkins-external"
     elsif hostname.include?("jenkins-cassandra")
       "jenkins-external"
     elsif hostname =~ /openwhisk-vm\d-he-de/ # OpenWhisk Jenkins boxes


### PR DESCRIPTION
Change back to jenkins-external. This is a revert of a commit october 1st 2018 where these were made internal. We have Beam folks with accounts on these boxes. As a side effect of that change also, kubectl which gets installed only on external nodes, was no longer being installed, but is required by Beam. See INFRA-17713