### PR TITLE
infrastructure-cvs@apache.org => commits@infra.apache.org

### DIFF
--- a/modules/subversion_server/files/authorization/asf-mailer-dist.conf
+++ b/modules/subversion_server/files/authorization/asf-mailer-dist.conf
@@ -151,7 +151,7 @@ unlock_subject_prefix = svn unlock:
 from_addr = %(author)s@apache.org
 
 # send it to infrastructure so they can figure out why it didn't route properly
-to_addr = infrastructure-cvs@apache.org
+to_addr = commits@infra.apache.org
 
 # When set to one of the valid options, the mailer will create a diff
 # for the appropriate type of change in the repository.  If this contains
@@ -187,9 +187,9 @@ max_subject_length = 255
 # directory for a new module.
 [/]
 for_paths = .*
-to_addr = infrastructure-cvs@apache.org
+to_addr = commits@infra.apache.org
 # Exclude what [/incubator/PODLING] catches.  (Without this, it would be
-# to: infra-cvs,commits@podling.)
+# to: commits@infra,commits@podling.)
 # Exclude axis for the same reason.
 exclude_paths = (dev|release)/(incubator|axis|freemarker)/(.*)
 suppress_if_match = yes


### PR DESCRIPTION
Replace old list name (alias) with actual list name
This might help stop duplicate emails for commits to /META arriving at commits@