### PR TITLE
Hooks must be processed in alpha order

### DIFF
--- a/modules/gitbox/files/hooks/post-receive
+++ b/modules/gitbox/files/hooks/post-receive
@@ -25,7 +25,8 @@ def main():
         exit(1)
     HOOKS_DIR = os.path.join(ADMIN_DIR, "hooks", "post-receive.d")
     stdin = sys.stdin.read()
-    for hook in os.listdir(HOOKS_DIR):
+    # Hooks must be processed in alpha order
+    for hook in sorted(os.listdir(HOOKS_DIR)):
         hook = os.path.join(HOOKS_DIR, hook)
         if not is_executable(hook):
             continue

--- a/modules/gitbox/files/hooks/update
+++ b/modules/gitbox/files/hooks/update
@@ -25,7 +25,8 @@ def main():
     HOOKS_DIR = os.path.join(ADMIN_DIR, "hooks", "update.d")
     stdin = sys.stdin.read()
     if os.path.exists(HOOKS_DIR):
-        for hook in os.listdir(HOOKS_DIR):
+        # hooks must be processed in alpha order
+        for hook in sorted(os.listdir(HOOKS_DIR)):
             hook = os.path.join(HOOKS_DIR, hook)
             if not is_executable(hook):
                 continue


### PR DESCRIPTION
os.listdir is documented to return files in arbitrary order.

However hooks must be processed in alpha order, so the names must be sorted.