### PR TITLE
Allow rate-limiter to whitelist IPs or CIDR blocks

### DIFF
--- a/modules/httpd_rate_limiter/manifests/init.pp
+++ b/modules/httpd_rate_limiter/manifests/init.pp
@@ -7,6 +7,7 @@ class httpd_rate_limiter (
   $interval                 = '120',
   $cpumax                   = '60',
   $whitelist                = '',
+  $whiteips                 = '',
   $autoconf                 = false,
   $asfilter                 = false,
 ){

--- a/modules/httpd_rate_limiter/templates/rate-limit.lua.erb
+++ b/modules/httpd_rate_limiter/templates/rate-limit.lua.erb
@@ -37,6 +37,7 @@ local CPU_MAX =  tonumber('<%= @cpumax %>') or 60    -- Max CPU time allowed, in
                      -- Note that this is cpu per core, so if INTERVAL is 120, and 8 cores,
                      -- full utilization of the box would be 960
 local WHITELIST = "<%= @whitelist %>"
+local WHITEIPS = "<%= @whiteips %>"
 
 -- quick'n'dirty way of getting the base block,
 -- either /16 for IPv4 or /64 for IPv6
@@ -80,6 +81,14 @@ end
 function before(r)
     local cidr = get_block(r.useragent_ip)
     local logid = get_log_id(r, cidr)
+    
+    -- if IP is whitelisted, ignore counting
+    for xip in WHITEIPS:gmatch("%S+") do
+        if r.useragent_ip == xip then
+            _G.rtime = nil
+            return apache2.DECLINED
+        end
+    end
     
     -- If the URI is whitelisted, ignore counting
     for uri in WHITELIST:gmatch("%S+") do

--- a/modules/httpd_rate_limiter/templates/rate-limit.lua.erb
+++ b/modules/httpd_rate_limiter/templates/rate-limit.lua.erb
@@ -84,7 +84,7 @@ function before(r)
     
     -- if IP is whitelisted, ignore counting
     for xip in WHITEIPS:gmatch("%S+") do
-        if r.useragent_ip == xip then
+        if r.useragent_ip == xip or cidr == xip then
             _G.rtime = nil
             return apache2.DECLINED
         end


### PR DESCRIPTION
Defaults to nothing for now, we can adjust and add a default later