### PR TITLE
Add locking so we dont run multiple migrations at once. Clean the output dir prior to a new migration attempt.

### DIFF
--- a/modules/selfserve_portal/files/populate-properties.sh
+++ b/modules/selfserve_portal/files/populate-properties.sh
@@ -34,7 +34,8 @@ fi
 
 # check project dir exists
 if [ ! -d "$BASEDIR/projects/$PROJECT" ]; then
-    echo "This project doesnt seem to exist: exiting."
+    echo "This project doesnt seem to exist: removing lockfile and exiting."
+    rm -f ${LOCKFILE}
 exit 1;
 fi
 

--- a/modules/selfserve_portal/files/populate-properties.sh
+++ b/modules/selfserve_portal/files/populate-properties.sh
@@ -12,8 +12,25 @@ PROJECT=$1
 SPACE=$2
 HISTORY=$3
 
-# check project dir exists
+LOCKFILE="/tmp/migratemoin.lock"
 
+# check we arent already running a migration
+if [ -f ${LOCKFILE} ]; then
+    echo "A lockfile ${LOCKFILE} already exists. Please try the migration tool again later.";
+    exit 1;
+  fi
+}
+
+# acquire lock
+touch ${LOCKFILE}
+
+# clean the output directory from any previous runs
+if [ -d "$BASEDIR/output/output" ];then
+  echo "Cleaning out output directory from previous runs..."
+  rm -rf $BASEDIR/output/output
+fi
+
+# check project dir exists
 if [ ! -d "$BASEDIR/projects/$PROJECT" ]; then
     echo "This project doesnt seem to exist: exiting."
 exit 1;
@@ -38,3 +55,7 @@ if [ $HISTORY == true ]; then
   /bin/sed -i s'|#MoinMoin.0003|MoinMoin.0003|' $CONFDIR/converter.moinmoin.properties  
 fi
 
+# release lock
+rm -f ${LOCKFILE}
+
+exit 0;

--- a/modules/selfserve_portal/files/populate-properties.sh
+++ b/modules/selfserve_portal/files/populate-properties.sh
@@ -16,13 +16,15 @@ LOCKFILE="/tmp/migratemoin.lock"
 
 # check we arent already running a migration
 if [ -f ${LOCKFILE} ]; then
-    echo "A lockfile ${LOCKFILE} already exists. Please try the migration tool again later.";
+    RUNNING=`cat ${LOCKFILE}`
+    echo "A lockfile ${LOCKFILE} already exists. Seems that ${RUNNING} migration is under way";
+    echo "Please try the migration tool again later.";
     exit 1;
   fi
 }
 
 # acquire lock
-touch ${LOCKFILE}
+echo "${PROJECT} > ${LOCKFILE}
 
 # clean the output directory from any previous runs
 if [ -d "$BASEDIR/output/output" ];then

--- a/modules/selfserve_portal/files/populate-properties.sh
+++ b/modules/selfserve_portal/files/populate-properties.sh
@@ -24,7 +24,7 @@ if [ -f ${LOCKFILE} ]; then
 }
 
 # acquire lock
-echo "${PROJECT} > ${LOCKFILE}
+echo "${PROJECT}" > ${LOCKFILE}
 
 # clean the output directory from any previous runs
 if [ -d "$BASEDIR/output/output" ];then


### PR DESCRIPTION
Add locking so we dont run multiple migrations at once. Clean the output dir prior to a new migration attempt.