### PR TITLE
Delete excluded files from dest

### DIFF
--- a/modules/selfserve_portal/files/sync-moin-all.sh
+++ b/modules/selfserve_portal/files/sync-moin-all.sh
@@ -8,5 +8,6 @@ cd $MOINDATA
     --include data/\*/data/pages         \
     --include data/\*/data/user         \
     --exclude-from /usr/local/etc/moin-to-cwiki/universal-wiki-converter/exclude-list.txt \
+    --delete --delete-excluded \
     rsync://apb-moin@moin-vm/moin $MOINDATA
 

--- a/modules/selfserve_portal/files/sync-moin-project.sh
+++ b/modules/selfserve_portal/files/sync-moin-project.sh
@@ -17,5 +17,6 @@ cd $MOINDATA
     --include data/pages         \
     --include data/user         \
     --exclude-from /usr/local/etc/moin-to-cwiki/universal-wiki-converter/exclude-list.txt \
+    --delete --delete-excluded \
     rsync://apb-moin@moin-vm/moin/$PROJECT $MOINDATA
 


### PR DESCRIPTION
Update the rsync scripts to remove files not on the source, and files in the exclude list.

This avoids having to start again if the exclude file list is changed or if a project tidies up their Moin Wiki before starting a transfer