### PR TITLE
Wrong local IP for mailprivate-vm2

### DIFF
--- a/data/nodes/mbox-vm.apache.org.yaml
+++ b/data/nodes/mbox-vm.apache.org.yaml
@@ -37,7 +37,7 @@ rsync::server::module:
     read_only: 'yes'
   private:
     path: '/x1'
-    hosts_allow: '10.10.3.60'
+    hosts_allow: '10.10.3.175'
     auth_users: 'apb-mailprivate'
     secrets_file: '/etc/rsyncd.secrets'
     incoming_chmod: false


### PR DESCRIPTION
Getting error from mbox-vm:
@ERROR: access denied to private from UNKNOWN (10.10.3.175)
rsync error