### PR TITLE
run the rename script if checkbos checked for rename FrontPage to Home. By default, new Confluence spaves are created with a Home page - this overwrites the existing Home page as a new version.

### DIFF
--- a/modules/selfserve_portal/files/mv-FrontPage-to-Home.sh
+++ b/modules/selfserve_portal/files/mv-FrontPage-to-Home.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Need to specify a project name as an arg: exiting."
+exit 1;
+fi
+
+MOINDATA="/usr/local/etc/moin-to-cwiki/universal-wiki-converter/projects"
+PROJECT=$1
+
+echo "Renaming FrontPage to Home for the $1 project..."
+sleep 1
+
+cd $MOINDATA/$PROJECT
+
+# Lets check if we have a FrontPage, else exit.
+
+if [ -d "data/pages/FrontPage" ]; then
+  #rename the page History log entries to say Home.
+  perl -pi -e s'|FrontPage|Home|g' data/pages/FrontPage/edit-log
+
+  # rename metatag in each revision file
+  perl -pi -e s'|##master-page:FrontPage|##master-page:Home|' data/pages/FrontPage/revisions/*
+
+  # finally, rename the Frontpage dir to Home
+  /bin/mv data/pages/FrontPage data/pages/Home
+else
+  echo "No FrontPage exists, so doing nothing"
+exit 0;
+fi
+

--- a/modules/selfserve_portal/files/www/site/cgi-bin/migratemoin.cgi
+++ b/modules/selfserve_portal/files/www/site/cgi-bin/migratemoin.cgi
@@ -45,6 +45,7 @@ if not space or not re.match(r"^[A-Z0-9]+$", space):
     sscommon.buggo("Invalid Confluence Space name!")
 
 history = form.getvalue('history', 'false')
+renametohome = form.getvalue('Home Page', 'false')
 
 moinscript = '%s/run_cmdline.sh' % moinpath
 settingsconf = 'confluenceSettings.properties'

--- a/modules/selfserve_portal/files/www/site/cgi-bin/migratemoin.cgi
+++ b/modules/selfserve_portal/files/www/site/cgi-bin/migratemoin.cgi
@@ -66,6 +66,10 @@ try:
     # Fetch Moin wiki data subdirs 'pages' and 'user' from moin-vm
     subprocess.check_output(['%s/sync-moin-project.sh %s' % (moinpath, moinwiki)],shell=True, stderr=subprocess.STDOUT)
 
+    # rename FrontPage to Home only if checked
+    if renametohome:
+        subprocess.check_output(['%s/mv-FrontPage-to-Home.sh %s' % (moinpath, moinwiki)],shell=True, stderr=subprocess.STDOUT)
+
     # Export the moin pages to txt format before converting to Confluence format.
     # Save to a $moinwiki-pages-out directory for processing
     subprocess.check_output(['%s -e conf/%s' % (moinscript, exporterconf)],shell=True, stderr=subprocess.STDOUT)

--- a/modules/selfserve_portal/files/www/site/js/moinform.json
+++ b/modules/selfserve_portal/files/www/site/js/moinform.json
@@ -26,6 +26,15 @@
                   "type": "checkbox"
              }
           }
-      }
+      }, {
+         "title": "options",
+         "fields": {
+           "Home Page": {
+             "desc": "Rename FrontPage to Home",
+             "type": "checkbox"
+    }
+  },
+  "footer": "<div style='float: left; width: 100%; margin-top: 20px; background: #FFD; border: 1px dotted #666;'><p>If ticked, the moin FrontPage will be renamed to the default confluence Home page.</p></div>"
+}
   ]
 }

--- a/modules/selfserve_portal/manifests/init.pp
+++ b/modules/selfserve_portal/manifests/init.pp
@@ -78,6 +78,12 @@ file {
       owner  => 'root',
       group  => 'root',
       mode   => '0755';
+    "${uwc_dir}/mv-FrontPage-to-Home.sh":
+      ensure => present,
+      source => 'puppet:///modules/selfserve_portal/mv-FrontPage-to-Home.sh',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755';
     "${uwc_dir}/exclude-list.txt":
       ensure => present,
       source => 'puppet:///modules/selfserve_portal/exclude-list.txt',


### PR DESCRIPTION
run the rename script if checkbos checked for rename FrontPage to Home. By default, new Confluence spaves are created with a Home page - this overwrites the existing Home page as a new version.