### PR TITLE
INFRA-18405 - accept mail sent to whimsy.a.o

### DIFF
--- a/data/nodes/whimsy-vm4.apache.org.yaml
+++ b/data/nodes/whimsy-vm4.apache.org.yaml
@@ -41,6 +41,9 @@ postfix::server::mailbox_command: '/usr/bin/procmail -a "$EXTENSION"'
 postfix::server::smtpd_tls_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
 postfix::server::smtpd_tls_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
 
+# ensure server also accepts mail to the generic host name
+postfix::server::mydestination: "whimsy.apache.org, %{::fqdn}, localhost.%{::domain}, localhost"
+
 logrotate::rule:
   apache2:
     ensure: 'present'


### PR DESCRIPTION
This is intended to allow mail to be accepted by whimsy-vmn.a.o if it is sent to @whimsy.a.o.

I assume it is OK for multiple hosts to include the same mydestination entry.
i.e. it won't cause problems if whimsy-vm5 is set up with the same setting.