### PR TITLE
Enabling slack jira bridge for Cassandra

### DIFF
--- a/modules/jira_slack_bridge/files/slackbridge.yaml
+++ b/modules/jira_slack_bridge/files/slackbridge.yaml
@@ -1,4 +1,10 @@
 subscriptions:
+    cassandra:
+        channel: "#cassandra"
+        jira: CASSANDRA
+    cassandra-dev:
+        channel: "#cassandra-dev"
+        jira: CASSANDRA
     infra:
         channel: "#asfinfra"
         jira: INFRA


### PR DESCRIPTION
Enabling slack jira bridge for Cassandra