### PR TITLE
Remove unnecessary "notification enabled" notification

### DIFF
--- a/modules/jira_slack_bridge/templates/jira-slack-bridge.py.erb
+++ b/modules/jira_slack_bridge/templates/jira-slack-bridge.py.erb
@@ -128,7 +128,6 @@ def main():
             if cname == thischan:
                 v['cid'] = cid
                 print("Found %s as %s, subbing it to %s" % (cname, cid, v.get('jira', 'FOO')))
-                sendNotice([{'text': "JIRA notifications for %s enabled..." % v.get('jira', 'FOO')}], cid)
         
     
     last_ticket = {}


### PR DESCRIPTION
Log reconnections on the server, but this is unnecessary noise on a channel. Please, remove.
![slack-notification-notification](https://user-images.githubusercontent.com/72494/59076858-ba65fd80-889d-11e9-92f3-722653815fb1.png)
