### PR TITLE
fix permissions for /pmc private areas

### DIFF
--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -832,7 +832,7 @@ openejb-tck = r
 * =
 
 [/pmc/accumulo]
-@accumulo = rw
+@accumulo-pmc = rw
 
 [/pmc/airavata]
 @airavata-pmc = rw
@@ -841,7 +841,7 @@ openejb-tck = r
 @apex-pmc = rw
 
 [/pmc/apr]
-@apr = rw
+@apr-pmc = rw
 
 [/pmc/archiva]
 @archiva-pmc = rw
@@ -868,7 +868,7 @@ openejb-tck = r
 @cloudstack-pmc = rw
 
 [/pmc/cocoon]
-@cocoon = rw
+@cocoon-pmc = rw
 
 [/pmc/comdev]
 @comdev-pmc = rw
@@ -966,7 +966,7 @@ openejb-tck = r
 @security = rw
 
 [/pmc/jackrabbit]
-@jackrabbit = rw
+@jackrabbit-pmc = rw
 
 # [/pmc/jakarta]
 # @jakarta-pmc = rw
@@ -999,7 +999,7 @@ openejb-tck = r
 @maven-pmc = rw
 
 [/pmc/myfaces]
-@myfaces = rw
+@myfaces-pmc = rw
 
 [/pmc/nifi]
 @nifi-pmc = rw
@@ -1056,10 +1056,10 @@ openejb-tck = r
 @synapse-pmc = rw
 
 [/pmc/tapestry]
-@tapestry = rw
+@tapestry-pmc = rw
 
 [/pmc/tcl]
-@tcl = rw
+@tcl-pmc = rw
 
 [/pmc/thrift]
 @thrift-pmc = rw
@@ -1083,7 +1083,7 @@ openejb-tck = r
 @whimsy-pmc = rw
 
 [/pmc/wicket]
-@wicket = rw
+@wicket-pmc = rw
 
 [/pmc/ws]
 @ws-pmc = rw


### PR DESCRIPTION
As per the discussions on private@infra and the relevate PMC lists, please update the PMC private area permissions:

Accumulo: https://lists.apache.org/thread.html/1733bbaa75a90626c7ac696e66e00b402c8b3cda4cfb13a8512d4e97@%3Cprivate.infra.apache.org%3E

APR: https://lists.apache.org/thread.html/5f78735d3a6d53af319d60012fcbef87483d581d0546823544cc7520@%3Cprivate.infra.apache.org%3E

Cocoon: https://lists.apache.org/thread.html/f9d018a481fecc8ece22dc1fc89480085c69b05dfc73e41939664b4e@%3Cprivate.infra.apache.org%3E

Jackrabbit: https://lists.apache.org/thread.html/91238d34be631604b4b039e8d2bcb22fcaf5775a77202aca82140232@%3Cprivate.infra.apache.org%3E

MyFaces: https://lists.apache.org/thread.html/8c714da424e494059f2b9538d423e9673582daed3975ce00b08783b8@%3Cprivate.infra.apache.org%3E

Tapestry: https://lists.apache.org/thread.html/7a919c1224545f1c2b7342f02308f07d03025dd39805aee8c6b1ae3a@%3Cprivate.infra.apache.org%3E

TCL: https://lists.apache.org/thread.html/1db9e854e44ec18db0ff11eb9c0198e248275ae83cce182429ce6903@%3Cprivate.infra.apache.org%3E

Wicket: https://lists.apache.org/thread.html/4e4c85e0f232a8c97cc1791907fa281c208506c376da0fac77caafe0@%3Cprivate.infra.apache.org%3E