### PR TITLE
restrict access to Ant PMC private svn

### DIFF
--- a/modules/subversion_server/files/authorization/pit-authorization-template
+++ b/modules/subversion_server/files/authorization/pit-authorization-template
@@ -837,6 +837,9 @@ openejb-tck = r
 [/pmc/airavata]
 @airavata-pmc = rw
 
+[/pmc/ant]
+@ant-pmc = rw
+
 [/pmc/apex]
 @apex-pmc = rw
 


### PR DESCRIPTION
This restricts access to the newly created svn area for Ant to its PMC members.