### PR TITLE
correct an IP matcher regex

### DIFF
--- a/modules/customfact/lib/facter/customfact.rb
+++ b/modules/customfact/lib/facter/customfact.rb
@@ -50,7 +50,7 @@ Facter.add("asfcolo") do
         "rackspace"
       when /^67.195.81.([0-9]+)$/
         "yahoo"
-      when /^172\.31\.3[2-9]|4[0-7]\.\d+$/
+      when /^172.31.(3[2-9]|4[0-7]).([0-9]+)$/
         "amz-vpc-virginia-1b"
       when /^10.0.([0-9]+).([0-9]+)$/
         "amz-vpc-virginia-1d"


### PR DESCRIPTION
Ruby doesn't need escapes on the dots. Narrow the | operator. Switch from \d to [0-9] like the others.