### PR TITLE
Alias for pmc-chairs

### DIFF
--- a/modules/mboxer/manifests/init.pp
+++ b/modules/mboxer/manifests/init.pp
@@ -81,6 +81,12 @@ class mboxer (
       provider  => aliases,
       notify    => Exec['newaliases'],
       recipient => "|python3 ${install_base}/tools/archive.py --lid ea@apache.org private";
+    'pmc-chairs':
+      ensure    => present,
+      name      => 'pmc-chairs',
+      provider  => aliases,
+      notify    => Exec['newaliases'],
+      recipient => "|python3 ${install_base}/tools/archive.py --lid pmc-chairs@apache.org private";
     'president':
       ensure    => present,
       name      => 'president',


### PR DESCRIPTION
This is needed to allow mbox to archive the pmc-chairs alias