### PR TITLE
Remove no-longer-supported release branches

### DIFF
--- a/modules/svnqavm_pvm_asf/manifests/init.pp
+++ b/modules/svnqavm_pvm_asf/manifests/init.pp
@@ -42,7 +42,7 @@ class svnqavm_pvm_asf (
 
     # Run backport merges
     'backport-cron':
-      command     => 'for i in 1.6.x 1.7.x 1.8.x 1.9.x 1.10.x 1.11.x 1.12.x; do cd && cd src/svn/$i && $SVN up -q --non-interactive && YES=1 MAY_COMMIT=1 ../trunk/tools/dist/backport.pl; done', # lint:ignore:140chars
+      command     => 'for i in 1.9.x 1.10.x 1.12.x; do cd && cd src/svn/$i && $SVN up -q --non-interactive && YES=1 MAY_COMMIT=1 ../trunk/tools/dist/backport.pl; done', # lint:ignore:140chars
       user        => 'svnsvn',
       hour        => 4,
       minute      => 0,


### PR DESCRIPTION
Remove no-longer-supported release branches from the backport checker.