### PR TITLE
Make 'upcoming changes' look at 'latest' branch

### DIFF
--- a/modules/svnqavm_pvm_asf/manifests/init.pp
+++ b/modules/svnqavm_pvm_asf/manifests/init.pp
@@ -64,7 +64,7 @@ class svnqavm_pvm_asf (
       environment => 'SVN=/usr/local/svn-current/bin/svn';
 
     'Update our upcoming changes list':
-      command     => 'cd ~/src/svn/1.11.x && chronic ~/src/svn/site/tools/generate-upcoming-changes-log.sh',
+      command     => 'cd ~/src/svn/latest && chronic ~/src/svn/site/tools/generate-upcoming-changes-log.sh',
       user        => 'svnsvn',
       hour        => 4,
       minute      => 15,


### PR DESCRIPTION
Make the 'upcoming changes' generator look at a 'latest' symlink instead of hard-coding the branch name in here.