### PR TITLE
INFRA-18906: publish camel-website to root

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -53,7 +53,7 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/bookkeeper.apache.org/content/distributedlog:  $gitbox/distributedlog
 /www/calcite.apache.org:            $gitbox/calcite-site:master
 /www/carbondata.apache.org:         $gitbox/carbondata-site
-/www/camel.apache.org/content/staging: $gitbox/camel-website
+/www/camel.apache.org:              $gitbox/camel-website
 /www/cayenne.apache.org:            $gitbox/cayenne-website
 /www/celix.apache.org:              $github/celix-site
 /www/cloudstack.apache.org:         $gitbox/cloudstack-www

--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -43,7 +43,6 @@ LANG: en_US.UTF-8
 /www/bugs.apache.org: %(ASF)s/bugs
 /www/buildr.apache.org: %(ASF)s/buildr/site
 /www/bval.apache.org: %(CMS)s/bval
-/www/camel.apache.org: %(CMS)s/camel
 /www/cassandra.apache.org: %(ASF)s/cassandra/site/publish
 /www/chemistry.apache.org: %(CMS)s/chemistry
 /www/chukwa.apache.org/content:  %(ASF)s/chukwa/site/publish


### PR DESCRIPTION
This publishes the content of `asf-git` branch in the `camel-website` gitbox repository to camel.apache.org/ (it used to publish to camel.apache.org/staging/) and disables the publish from SVN.