### PR TITLE
Use RVM to install Ruby 2.6.3

### DIFF
--- a/data/nodes/bb-slave2.apache.org.yaml
+++ b/data/nodes/bb-slave2.apache.org.yaml
@@ -18,6 +18,8 @@ ruby_version: '2.3.1'
 
 rvm::system_rubies:
   "ruby-%{hiera('ruby_version')}": {}
+    default_use: true
+  "ruby-2.6.3"
 
 rvm::system_users:
   - buildslave


### PR DESCRIPTION
Ruby 2.6.3 (latest stable version) installed on bb-slave2 with Ruby
2.3.1 (currently installed) set as the default