### PR TITLE
Revert gitwcsub tracking branch for arrow.apache.org to asf-site

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -43,7 +43,7 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/apex.apache.org:               $gitbox/apex-site
 /www/archiva.apache.org:            $gitbox/archiva-web-content:master
 /www/ariatosca.apache.org:          $gitbox/incubator-ariatosca-website
-/www/arrow.apache.org:              $gitbox/arrow-site:master
+/www/arrow.apache.org:              $gitbox/arrow-site
 /www/asterixdb.apache.org:          $gitbox/asterixdb-site
 /www/atlas.apache.org:              $gitbox/atlas-website
 /www/bahir.apache.org:              $gitbox/bahir-website


### PR DESCRIPTION
Our website deploys from asf-site have stopped working likely on account of this.

See

* https://issues.apache.org/jira/browse/INFRA-18987
* https://issues.apache.org/jira/browse/INFRA-18914