### PR TITLE
remove a useless script from y nodes

### DIFF
--- a/modules/build_slaves/manifests/jenkins.pp
+++ b/modules/build_slaves/manifests/jenkins.pp
@@ -662,6 +662,11 @@ class build_slaves::jenkins (
       recurse => '1',
   }
 
+  file {
+    '/etc/cron.hourly/fixes':
+      ensure => absent,
+  }
+
   service { 'apache2':
     ensure => 'stopped',
   }


### PR DESCRIPTION
this script preinstalled on the y nodes emits a useless cron error every
hour and does nothing of note since unattended upgrades are alredy
enabled.