### PR TITLE
INFRA-19263: Threading of GitBox email messages

### DIFF
--- a/modules/gitbox/files/cgi-bin/issues.cgi
+++ b/modules/gitbox/files/cgi-bin/issues.cgi
@@ -108,6 +108,7 @@ def issueOpened(payload):
     fmt['type'] = 'issue'
     if 'pull_request' in payload:
         fmt['type'] = 'pull request'
+    fmt['node_id'] = obj['node_id'] # Stable global issue/pr id
     fmt['id'] = obj['number']
     fmt['text'] = obj['body']
     fmt['title'] = obj['title']
@@ -371,7 +372,7 @@ def main():
         # Go ahead and generate the template
         email = formatMessage(fmt)
     if email:
-        thread_id = "<issue.%s.%s.gitbox@gitbox.apache.org>" % (fmt['id'], project)
+        thread_id = "<%s.%s.%s.gitbox@gitbox.apache.org>" % (project, fmt['id'], fmt['node_id'])
         message_id = thread_id if isNew else None
         reply_to_id = thread_id if not isNew else None
         sendEmail(mailto, email['subject'], email['message'], message_id = message_id, reply_to_id = reply_to_id)


### PR DESCRIPTION
See https://issues.apache.org/jira/projects/INFRA/issues/INFRA-19263

Rough attempt at implementing threading support for PR notifications, so that all email sent by the script for the same project and same issue/PR id will be grouped in the same email thread by mail clients, as per RFC2822 - https://tools.ietf.org/html/rfc2822.html#section-3.6.4

For new issues/PRs only, the `Message-ID` header of the email is set as `<issue.$ISSUEID.$PROJECTNAME.gitbox@gitbox.apache.org>`, for all other emails the message id is auto generated as before. For followup issues/PRs, such as comments, the `In-Reply-To` and `References` headers are set to that exact stable id.

For obvious reasons the changes are not tested, so this is an input to INFRA which may need some testing and adjustment before ready.