### PR TITLE
feat: support GH feature settings in .asf.yaml

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -90,6 +90,7 @@ def github(cfg, yml):
         desc = yml.get('description')
         homepage = yml.get('homepage')
         merges = yml.get('enabled_merge_buttons')
+        features = yml.get('features')
         topics = yml.get('labels')
         ghp_branch = yml.get('ghp_branch')
         ghp_path = yml.get('ghp_path', '/docs')
@@ -99,9 +100,13 @@ def github(cfg, yml):
         if homepage:
             repo.edit(homepage=homepage)
         if merges:
-             repo.edit(allow_squash_merge=merges.get("squash", False),
+            repo.edit(allow_squash_merge=merges.get("squash", False),
                 allow_merge_commit=merges.get("merge", False),
                 allow_rebase_merge=merges.get("rebase", False))
+        if features:
+            repo.edit(has_issues=features.get("issues", False),
+                has_wiki=features.get("wiki", False),
+                has_projects=features.get("projects", False))
         if topics and type(topics) is list:
             for topic in topics:
                 if not re.match(r"^[-a-z0-9]{1,35}$", topic):


### PR DESCRIPTION
_**Note:** If there is a specific process in submitting a PR or feature request to INFRA in regards to this area, I am sorry ahead of time as I am not fully aware and would like to also learn the proper process. I had only read the contents from the Workflow link in README _

# Feature Request

Support GitHub default feature settings.

## Motivation Behind Feature

It would be nice to be able to enable and disable the primary GitHub features with out needing to submit an INFRA ticket.

### GitHub's Primary Features:
* Wikis
* Restrict editing to collaborators only
  * This is a wiki related option.
* Issues
* Sponsorships
* Projects

## Feature Description

This PR only focuses on providing support for the follow features:

* Wikis (`has_wiki`)
* Issues (`has_issues`)
* Projects (`has_projects`)

The parameter `name` are documented in https://developer.github.com/v3/repos/#edit

Example `.asf.yaml` configurations

```yaml
github:
  features:
    # enable wiki
    wiki: true
    # enable issues
    issues: true
    # enable projects
    projects: true
```

## Alternatives or Workarounds

Submitting an INFRA ticket in JIRA.

## Future Thoughts

The ability to support enable/disable:

**Sponsorships** - APIv3 docs has no information regarding to the parameter `name` for this option, but from the ChromeDev network tab, the parameter `name` might be `enable_repository_funding_links`.

**Restrict editing to collaborators only** - APIv3 docs has no information regarding to the parameter `name` for this option, but from the ChromeDev network tab, the parameter `name` might be `wiki_access_to_pushers`.