### PR TITLE
Added the ACL for INFRA-19237

### DIFF
--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -166,8 +166,8 @@ overlay syncprov
 ############################################################################################
 
 ## Service user that will recreate the ou=meta see INFRA-19237 
-access to dn.subtree="ou=group,dc=apache,dc=org"
-  attrs=ou
+access to dn.subtree="ou=groups,dc=apache,dc=org"
+  attrs=ou,cn
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=genmeta-rw,ou=users,ou=services,dc=apache,dc=org" write  
   by dn="cn=idao-ro,ou=users,ou=services,dc=apache,dc=org" read

--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -165,7 +165,7 @@ overlay syncprov
 
 ############################################################################################
 
-## Service user that will recreate the 
+## Service user that will recreate the ou=meta see INFRA-19237 
 access to dn.subtree="ou=group,dc=apache,dc=org"
   attrs=ou
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write

--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -167,7 +167,7 @@ overlay syncprov
 
 ## Service user that will recreate the ou=meta see INFRA-19237 
 access to dn.subtree="ou=groups,dc=apache,dc=org"
-  attrs=ou,cn
+  attrs=ou
   by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
   by dn="cn=genmeta-rw,ou=users,ou=services,dc=apache,dc=org" write  
   by dn="cn=idao-ro,ou=users,ou=services,dc=apache,dc=org" read

--- a/modules/ldapserver/templates/slapd.conf.erb
+++ b/modules/ldapserver/templates/slapd.conf.erb
@@ -165,6 +165,18 @@ overlay syncprov
 
 ############################################################################################
 
+## Service user that will recreate the 
+access to dn.subtree="ou=group,dc=apache,dc=org"
+  attrs=ou
+  by group.exact="cn=apldap,ou=groups,ou=services,dc=apache,dc=org" write
+  by dn="cn=genmeta-rw,ou=users,ou=services,dc=apache,dc=org" write  
+  by dn="cn=idao-ro,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=ldaprepl,ou=users,ou=services,dc=apache,dc=org" read
+  by dn="cn=nss_ldap,ou=users,ou=services,dc=apache,dc=org" read
+  by * read
+  by anonymous auth
+
+
 ## Allow users, and selfserve to modify a users password.
 access to dn.subtree="ou=people,dc=apache,dc=org"
   attrs=userPassword


### PR DESCRIPTION
genmeta-rw should be able to re-create the ou=meta for project owner data.