### PR TITLE
Create 9.x examples site and force SSL

### DIFF
--- a/data/nodes/wicket-vm.apache.org.yaml
+++ b/data/nodes/wicket-vm.apache.org.yaml
@@ -20,7 +20,7 @@ vhosts_asf::vhosts::vhosts:
     serveraliases:
       - 'www.examples6x.wicket.apache.org'
     port: 80
-    ssl: false
+    ssl: true
     docroot: '/var/www'
     error_log_file: 'examples6x_error.log'
     custom_fragment: |
@@ -33,7 +33,7 @@ vhosts_asf::vhosts::vhosts:
     serveraliases:
       - 'www.examples7x.wicket.apache.org'
     port: 80
-    ssl: false
+    ssl: true
     docroot: '/var/www'
     error_log_file: 'examples7x_error.log'
     custom_fragment: |
@@ -46,7 +46,7 @@ vhosts_asf::vhosts::vhosts:
     serveraliases:
       - 'www.examples8x.wicket.apache.org'
     port: 80
-    ssl: false
+    ssl: true
     docroot: '/var/www'
     error_log_file: 'examples8x_error.log'
     custom_fragment: |
@@ -57,5 +57,24 @@ vhosts_asf::vhosts::vhosts:
       RewriteCond %%{}{HTTP:UPGRADE} websocket [NC]
       RewriteCond %%{}{HTTP:CONNECTION} Upgrade$ [NC]
       RewriteRule .* ws://127.0.0.1:8088%%{}{REQUEST_URI} [P]
+      ProxyPreserveHost On
+  examples9x-80:
+    vhost_name: '*'
+    priority: '12'
+    servername: 'examples9x.wicket.apache.org'
+    serveraliases:
+      - 'www.examples9x.wicket.apache.org'
+    port: 80
+    ssl: true
+    docroot: '/var/www'
+    error_log_file: 'examples9x_error.log'
+    custom_fragment: |
+      ProxyPass / http://127.0.0.1:8089/
+      ProxyPassReverse / http://127.0.0.1:8089/
+      #websockets
+      RewriteEngine On
+      RewriteCond %%{}{HTTP:UPGRADE} websocket [NC]
+      RewriteCond %%{}{HTTP:CONNECTION} Upgrade$ [NC]
+      RewriteRule .* ws://127.0.0.1:8089%%{}{REQUEST_URI} [P]
       ProxyPreserveHost On
       

--- a/modules/wicket_pvm_asf/manifests/init.pp
+++ b/modules/wicket_pvm_asf/manifests/init.pp
@@ -37,6 +37,15 @@ class wicket_pvm_asf (
       require => Package['docker-engine'],
       notify  => Service['docker-wicket-demo-8'],
   }
+# for wicket-9
+  exec {
+    'download-wicket-docker-9':
+      command => '/usr/bin/docker pull apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-9',
+      timeout => 1200,
+      require => Package['docker-engine'],
+      notify  => Service['docker-wicket-demo-9'],
+  }
+
 
   docker::run { 'wicket-demo-6':
     image            => 'apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-6',
@@ -64,6 +73,14 @@ class wicket_pvm_asf (
     pull_on_start    => true,
     extra_parameters => [ '--restart=always' ],
   }
-
+  
+  docker::run { 'wicket-demo-9':
+    image            => 'apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-9',
+    ports            => ['8089:8080'],
+    restart_service  => true,
+    privileged       => false,
+    pull_on_start    => true,
+    extra_parameters => [ '--restart=always' ],
+  }
 }
 


### PR DESCRIPTION
Hi,

as discussed on our [mailing list ](http://mail-archives.apache.org/mod_mbox/wicket-dev/202001.mbox/%3CCAB63Y-d8kLUobxdJZ-qh2TCfT2VpD%2BEh7RUoOwd2Ec%2BQN0MJfg%40mail.gmail.com%3E) we would like to have an examples site also for the upcoming version 9 of Wicket. We also decided to serve our examples sites over SSL by default. I've changed the 2 config file accordingly. Please note that I've chosen port 8089 for the new 9.x site. I hope it's ok on your side.

Thank you.