### PR TITLE
Allow projects to define whitelists for GHPRB

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -22,7 +22,7 @@ def jenkins(cfg, yml):
     if ghprb_whitelist and type(ghprb_whitelist) is list:
         ghwl = "\n".join(ghprb_whitelist)
         print("Updating GHPRB whitelist for GitHub...")
-        with open("/x1/gitbox/conf/%s.txt" % cfg.repo_name, "w") as f:
+        with open("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % cfg.repo_name, "w") as f:
             f.write(ghwl)
             f.close()
         print("Whitelist updated!")

--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -15,6 +15,18 @@ WSMAP = {
     'infrastructure': 'infra',
 }
 
+def jenkins(cfg, yml):
+    
+    # GitHub PR Builder Whitelist for known (safe) contributors
+    ghprb_whitelist = yml.get('github_whitelist')
+    if ghprb_whitelist and type(ghprb_whitelist) is list:
+        ghwl = "\n".join(ghprb_whitelist)
+        print("Updating GHPRB whitelist for GitHub...")
+        with open("/x1/gitbox/conf/%s.txt" % cfg.repo_name, "w") as f:
+            f.write(ghwl)
+            f.close()
+        print("Whitelist updated!")
+
 def jekyll(cfg, yml):
     """ Jekyll auto-build """
     

--- a/modules/gitbox/files/cgi-bin/relay.cgi
+++ b/modules/gitbox/files/cgi-bin/relay.cgi
@@ -64,13 +64,25 @@ elif 'issue' in PAYLOAD:
         what = 'issue_comment'
 
 if what == 'pr':
+  # Is Proper Committer?
   is_asf = gh_to_ldap(PAYLOAD['pull_request']['user']['login'])
+  # Deemed safe committer by .asf.yaml?
+  if not is_asf and os.path.exists("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo):
+        ghprb_whitelist = open("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo).read().split("\n")
+        is_asf = PAYLOAD['pull_request']['user']['login'] in ghprb_whitelist
+  # If we don't trust, abort immediately
   if not is_asf:
     print("Status: 204 Handled\r\n\r\n")
     sys.exit(0)
 
 if what == 'pr_comment':
+  # Is Proper Committer?
   is_asf = gh_to_ldap(PAYLOAD['comment']['user']['login'])
+  # Deemed safe committer by .asf.yaml?
+  if not is_asf and os.path.exists("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo):
+        ghprb_whitelist = open("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo).read().split("\n")
+        is_asf = PAYLOAD['comment']['user']['login'] in ghprb_whitelist
+  # If we don't trust, abort immediately
   if not is_asf:
     print("Status: 204 Handled\r\n\r\n")
     sys.exit(0)

--- a/modules/gitbox/files/cgi-bin/relay.cgi
+++ b/modules/gitbox/files/cgi-bin/relay.cgi
@@ -69,7 +69,9 @@ if what == 'pr':
   # Deemed safe committer by .asf.yaml?
   if not is_asf and os.path.exists("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo):
         ghprb_whitelist = open("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo).read().split("\n")
-        is_asf = PAYLOAD['pull_request']['user']['login'] in ghprb_whitelist
+        if PAYLOAD['pull_request']['user']['login'] in ghprb_whitelist:
+            is_asf = True
+            log_entry('whitelist', "%s [%s]: %s payload for %s allowed via GHPRB Whitelist for %s" % (DATE, GUID, what, hook, PAYLOAD['pull_request']['user']['login']))
   # If we don't trust, abort immediately
   if not is_asf:
     print("Status: 204 Handled\r\n\r\n")
@@ -81,7 +83,9 @@ if what == 'pr_comment':
   # Deemed safe committer by .asf.yaml?
   if not is_asf and os.path.exists("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo):
         ghprb_whitelist = open("/x1/gitbox/conf/ghprb-whitelist/%s.txt" % repo).read().split("\n")
-        is_asf = PAYLOAD['comment']['user']['login'] in ghprb_whitelist
+        if PAYLOAD['comment']['user']['login'] in ghprb_whitelist:
+            is_asf = True
+            log_entry('whitelist', "%s [%s]: %s payload for %s allowed via GHPRB Whitelist for %s" % (DATE, GUID, what, hook, PAYLOAD['comment']['user']['login']))
   # If we don't trust, abort immediately
   if not is_asf:
     print("Status: 204 Handled\r\n\r\n")


### PR DESCRIPTION
This will allow projects to define GitHub users who should be allowed to push PRs to Jenkins via .asf.yaml.

Example .asf.yaml entry:

~~~
jenkins:
  ghprb_whitelist:
    - humbedooh
    - janedoe
    - githubmonkey
~~~