### PR TITLE
netbeans-vm.apache.org: Setting correct access and error log files of httpd

### DIFF
--- a/data/nodes/netbeans-vm.apache.org.yaml
+++ b/data/nodes/netbeans-vm.apache.org.yaml
@@ -94,8 +94,8 @@ vhosts_asf::vhosts::vhosts:
     ssl_proxyengine: true
     docroot:  '/var/www/html'
     access_log_format: 'combined'
-    access_log_file: "netbeans-vm_access.log"
-    error_log_file: "netbeans-vm_error.log"
+    access_log_file: 'netbeans-vm.apache.org_access.log'
+    error_log_file: 'netbeans-vm.apache.org_error.log'
     directories:
       -
         path: '/var/www/html'


### PR DESCRIPTION
Please review and merge my change which sets correct logfiles for netbeans-vm-ssl vhost on netbeans-vm.