### PR TITLE
Migrate MINA to gitpubsub

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -112,6 +112,9 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/mesos.apache.org:              $gitbox/mesos-site
 /www/metron.apache.org:             $gitbox/metron
 /www/milagro.apache.org:            $github/incubator-milagro
+/www/mina.apache.org:               $github/mina-site
+/www/mina.apache.org/content/mina-project/gen-docs: $github/mina-site:mina-gen-docs
+/www/mina.apache.org/content/sshd-project/apidocs: $github/mina-site:sshd-apidocs
 /www/mnemonic.apache.org:           $gitbox/mnemonic-site
 /www/mxnet.apache.org:              $gitbox/incubator-mxnet-site
 /www/mynewt.apache.org:             $gitbox/mynewt-site

--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -131,7 +131,6 @@ LANG: en_US.UTF-8
 /www/maven.apache.org/content/doxia: %(ASF)s/maven/doxia/website/content
 /www/maven.apache.org/content: %(ASF)s/maven/website/content
 /www/metamodel.apache.org: %(CMS)s/metamodel
-/www/mina.apache.org: %(CMS)s/mina
 /www/mrql.apache.org: %(ASF)s/incubator/mrql/site/trunk
 /www/myfaces.apache.org/wiki: %(CMS)s/myfaces/content/wiki
 /www/myfaces.apache.org: %(ASF)s/myfaces/site/publish


### PR DESCRIPTION
MINA [wants to migrate](https://lists.apache.org/thread.html/ra9014b092f25d3b4ad31d4251862c35c31d0a7ee0486ea3c9db59b0d%40%3Cdev.mina.apache.org%3E) from the Apache CMS and use git for serving its website.

[As discussed on slack](https://the-asf.slack.com/archives/CBX4TSBQ8/p1582565890030900) a follow-up PR will probably be created as well soon but this is just to get the first pieces in place and start using git.

Do I need to do something to get MINA deactivated from the [CMS](https://cms.apache.org/)?