### PR TITLE
Migrated Jena from svnpubsub to gitpubsub

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -96,6 +96,8 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/iotdb.apache.org:              $gitbox/incubator-iotdb-website
 /www/isis.apache.org:               $gitbox/isis-site
 /www/james.apache.org:              $gitbox/james-site
+/www/jena.apache.org:               $github/jena-site
+/www/jena.apache.org/content/documentation/javadoc: $github/jena-site:javadoc
 /www/jmeter.apache.org:             $gitbox/jmeter-site
 /www/joshua.apache.org:             $gitbox/joshua-site
 /www/jspwiki.apache.org/content:    $gitbox/jspwiki-site

--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -111,7 +111,6 @@ LANG: en_US.UTF-8
 /www/jackrabbit.apache.org: %(ASF)s/jackrabbit/site/live/
 /www/jakarta.apache.org: %(ASF)s/jakarta/site/docs
 /www/jclouds.apache.org:  %(ASF)s/jclouds/site-content/
-/www/jena.apache.org: %(CMS)s/jena
 /www/johnzon.apache.org: %(ASF)s/johnzon/site/publish/
 /www/karaf.apache.org: %(ASF)s/karaf/site/production
 /www/knox.apache.org:  %(ASF)s/knox/site/


### PR DESCRIPTION
The Jena [community voted](https://lists.apache.org/thread.html/ra90da10830d6575b75f2f43f08e2886e0fff898e6391092bd86dc3ae%40%3Cdev.jena.apache.org%3E) to migrate away from the Apache CMS and use git for serving its website.

After this `cms.a.o/jena` needs to be removed and the cms.conf needs to be edited.