### PR TITLE
Migrated community.a.o from svnpubsub to gitpubsub

### DIFF
--- a/modules/gitwcsub/files/config/gitwcsub.cfg
+++ b/modules/gitwcsub/files/config/gitwcsub.cfg
@@ -56,6 +56,7 @@ logLimit:             7       # Keep 7 days worth of old logs
 /www/cayenne.apache.org:            $gitbox/cayenne-website
 /www/celix.apache.org:              $github/celix-site
 /www/cloudstack.apache.org:         $gitbox/cloudstack-www
+/www/community.apache.org:          $gitbox/comdev-site
 /www/couchdb.apache.org:            $gitbox/couchdb-www
 /www/crail.apache.org:              $gitbox/incubator-crail-website
 /www/creadur.apache.org:            $gitbox/creadur-site

--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -49,7 +49,6 @@ LANG: en_US.UTF-8
 /www/climate.apache.org:  %(CMS)s/climate/
 /www/cocoon.apache.org: %(ASF)s/cocoon/site/site
 /www/commons.apache.org: %(CMS)s/commons
-/www/community.apache.org: %(CMS)s/community
 /www/concerted.apache.org: %(ASF)s/incubator/concerted/site/
 /www/continuum.apache.org: %(ASF)s//continuum/site-publish/
 /www/cordova.apache.org/content:  %(ASF)s/cordova/site/public


### PR DESCRIPTION
After [voting](https://lists.apache.org/thread.html/r84c367fb0942ae66b2d693e43e1f38f446fd726257325953d2fede05%40%3Cdev.community.apache.org%3E) this moves community.a.o from svnpubsub to gitpubsub.