### PR TITLE
Removed VCL site from svnpubsub

### DIFF
--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -199,7 +199,6 @@ LANG: en_US.UTF-8
 /www/twill.apache.org: %(ASF)s/twill/site/
 /www/uima.apache.org/pubsub: %(ASF)s/uima/site/trunk/uima-website/docs
 /www/unomi.apache.org: %(ASF)s/unomi/website/
-/www/vcl.apache.org: %(CMS)s/vcl
 /www/vxquery.apache.org/content:  %(ASF)s/vxquery/site/
 /www/whirr.apache.org: %(ASF)s/whirr/site/production
 /www/ws.apache.org: %(ASF)s/webservices/website


### PR DESCRIPTION
On hold till https://github.com/apache/vcl-site/pull/2 & https://github.com/apache/vcl-site/pull/3 are merged.