### PR TITLE
add /var/lib/lxcfs to bpc excludes

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -29,6 +29,7 @@ backuppc::client::backup_files_exclude:
   - /sys
   - /dev
   - /run
+  - /var/lib/lxcfs
 backuppc::client::backup_files_only:
   - /home
   - /usr


### PR DESCRIPTION
it is a dynamic system filesystem and causes bpc errors