### PR TITLE
force a client ping command to /bin/ping

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,6 +22,7 @@ stunnel_asf::stunnel_port: 4443
 backuppc::client::manage_rsync: false
 backuppc::client::manage_sudo: false
 
+backuppc::client::ping_cmd: '/bin/ping -c 1 -w 3 $host'
 backuppc::client::config_name: "%{::hostname}"
 backuppc::client::backuppc_hostname: 'backup02-he-de.apache.org'
 backuppc::client::backup_files_exclude:


### PR DESCRIPTION
this works around a backuppc bug where the ping command doesn't seem to
work with $pingPath as defined, so we hardcode /bin/ping.