### PR TITLE
default branch detection for .asf.yaml operations

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -2,6 +2,7 @@ import requests
 import json
 import asfgit.log
 import asfgit.git
+import asfgit.cfg
 import re
 import github as pygithub
 import os
@@ -432,9 +433,9 @@ def notifications(cfg, yml):
     # Get branch
     ref = yml.get('refname', 'master').replace('refs/heads/', '')
 
-    # Ensure this is master, or bail
-    if ref != 'master' and ref != 'trunk':
-        print("[NOTICE] Notification scheme settings can only be applied to the master or trunk branch.")
+    # Ensure this is master, trunk or repo's default branch - otherwise bail
+    if ref != 'master' and ref != 'trunk' and ref != asfgit.cfg.default_branch:
+        print("[NOTICE] Notification scheme settings can only be applied to the master/trunk or default branch.")
         return
 
     # Grab list of valid mailing lists

--- a/modules/gitbox/files/asfgit/cfg.py
+++ b/modules/gitbox/files/asfgit/cfg.py
@@ -77,6 +77,13 @@ max_emails = int(_git_config("hooks.asfgit.max-emails"))
 extra_writers = _git_config("hooks.asfgit.extra-writers", default='')
 extra_writers = extra_writers.split(',') if extra_writers != '' else []
 
+# Fetch default branch, default to master is repo is bare or has no default yet.
+default_branch = 'master'
+try:
+  default_branch = run.git('symbolic-ref', '--short', 'HEAD').strip()
+except sp.CalledProcessError as e:  # This can break when repo is bare, beware.
+  pass
+
 gitpubsub_host = _git_config("hooks.asfgit.pubsub-host", DEFAULT_PUBSUB_HOST)
 gitpubsub_port = _git_config("hooks.asfgit.pubsub-port", DEFAULT_PUBSUB_PORT)
 gitpubsub_path = _git_config("hooks.asfgit.pubsub-path", DEFAULT_PUBSUB_PATH)


### PR DESCRIPTION
This will allow notifications to be set using the default branch where that branch differs from 'master' or 'trunk'.