### PR TITLE
Allow for magic variable $default, pointing to default branch of any repo

### DIFF
--- a/modules/gitbox/files/asfgit/git.py
+++ b/modules/gitbox/files/asfgit/git.py
@@ -1,6 +1,6 @@
 import asfgit.run as run
 import asfgit.util as util
-
+import asfgit.cfg as cfg
 
 FIELDS = [
     ("commit", "%h"),
@@ -75,6 +75,10 @@ class RefUpdate(object):
         for p in patterns:
             # foo == foo
             if p == self.name:
+                return True
+            # magic variable $default, points to default branch.
+            # Since cfg.default_branch is using --short, we crop away refs/heads/ first.
+            if p == '$default' and self.name.replace('refs/heads/', '') == cfg.default_branch:
                 return True
             # foo/ == foo/bar but also foo exactly
             if p.endswith("/") and (self.name.startswith(p) or self.name == p[:-1]):

--- a/modules/gitbox/files/conf/gitconfig
+++ b/modules/gitbox/files/conf/gitconfig
@@ -15,7 +15,7 @@
 
 [hooks.asfgit]
     debug = false
-    protect = refs/heads/trunk refs/heads/master refs/heads/rel/ refs/tags/rel/
+    protect = refs/heads/trunk refs/heads/master $default refs/heads/rel/ refs/tags/rel/
     no-merges = false
     sendmail = /usr/local/sbin/sendmail
     recips = %(commit)s


### PR DESCRIPTION
This is for branch protection rules, allowing us to move away from 'master' and towards just pointing at the default branch, for those cases where the default needs protection but isn't called master.