### PR TITLE
Fix jdkHome for Java 1.9, remove jdk16 - INFRA-20938

### DIFF
--- a/environments/windows/modules/jenkins_node_windows/files/toolchains.xml
+++ b/environments/windows/modules/jenkins_node_windows/files/toolchains.xml
@@ -48,7 +48,7 @@
       <vendor>oracle</vendor>
     </provides>
     <configuration>
-      <jdkHome>F:\\jenkins\\tools\\java\\latest1.9\\</jdkHome>
+      <jdkHome>F:\\jenkins\\tools\\java\\latest9\\</jdkHome>
     </configuration>
   </toolchain>
   <toolchain>
@@ -111,6 +111,7 @@
       <jdkHome>F:\\jenkins\\tools\\java\\latest15\\</jdkHome>
     </configuration>
   </toolchain>
+  <!--
   <toolchain>
     <type>jdk</type>
     <provides>
@@ -121,4 +122,5 @@
       <jdkHome>F:\\jenkins\\tools\\java\\latest16\\</jdkHome>
     </configuration>
   </toolchain>
+  -->
 </toolchains>

--- a/environments/windows/modules/jenkins_node_windows/files/toolchains.xml
+++ b/environments/windows/modules/jenkins_node_windows/files/toolchains.xml
@@ -48,7 +48,7 @@
       <vendor>oracle</vendor>
     </provides>
     <configuration>
-      <jdkHome>F:\\jenkins\\tools\\java\\latest9\\</jdkHome>
+      <jdkHome>F:\\jenkins\\tools\\java\\latest1.9\\</jdkHome>
     </configuration>
   </toolchain>
   <toolchain>
@@ -111,7 +111,6 @@
       <jdkHome>F:\\jenkins\\tools\\java\\latest15\\</jdkHome>
     </configuration>
   </toolchain>
-  <!--
   <toolchain>
     <type>jdk</type>
     <provides>
@@ -122,5 +121,4 @@
       <jdkHome>F:\\jenkins\\tools\\java\\latest16\\</jdkHome>
     </configuration>
   </toolchain>
-  -->
 </toolchains>

--- a/environments/windows/modules/jenkins_node_windows/manifests/init.pp
+++ b/environments/windows/modules/jenkins_node_windows/manifests/init.pp
@@ -130,7 +130,7 @@ class jenkins_node_windows (
     provider => powershell,
   }
   exec { 'create symlink for JDK1.9':
-    command  => "cmd /c rmdir F:\\jenkins\\tools\\java\\latest9 \"&\" mklink /d F:\\jenkins\\tools\\java\\latest9 F:\\jenkins\\tools\\java\\jdk9.0.1",# lint:ignore:140chars
+    command  => "cmd /c rmdir F:\\jenkins\\tools\\java\\latest1.9 \"&\" mklink /d F:\\jenkins\\tools\\java\\latest1.9 F:\\jenkins\\tools\\java\\jdk9.0.1",# lint:ignore:140chars
     onlyif   => "if ((Get-Item F:\\tools_zips).LastWriteTime -lt (Get-Date).AddMinutes(-60)) { exit 1;}  else { exit 0; }",
     provider => powershell,
   }


### PR DESCRIPTION
This is a follow-up on https://issues.apache.org/jira/browse/INFRA-20938

* Fixes jdkHome for Java 1.9: It is `F:\\jenkins\\tools\\java\\latest9\\` and not `F:\\jenkins\\tools\\java\\latest1.9\\`
* Removes toolchain config for jdk16, since jdk16 doesn't seem to be available for windows nodes? At least, I couldn't find it in https://github.com/apache/infrastructure-puppet/blob/1d17bdd455b8f747d86e9c2ae6979284d763a752/environments/windows/modules/jenkins_node_windows/manifests/params.pp#L13
