### PR TITLE
Add openjdk16-ea+24 to all buildbot and jenkins nodes still using devops/puppet3

### DIFF
--- a/data/ubuntu/ubuntu_1404.yaml
+++ b/data/ubuntu/ubuntu_1404.yaml
@@ -459,6 +459,7 @@ build_slaves::jenkins::jenkins_packages:
   - asf-build-openjdk14-ea+1
   - asf-build-openjdk14-ea+10
   - asf-build-openjdk15-ea+11
+  - asf-build-openjdk16-ea+24
 
 # Not all build slaves. This is just for Jenkins slaves.
 build_slaves::distro_packages:

--- a/data/ubuntu/ubuntu_1604.yaml
+++ b/data/ubuntu/ubuntu_1604.yaml
@@ -447,6 +447,7 @@ build_slaves::jenkins::jenkins_packages:
   - asf-build-openjdk14-ea+1
   - asf-build-openjdk14-ea+10
   - asf-build-openjdk15-ea+11
+  - asf-build-openjdk16-ea+24
 
 # Not all build slaves. This is just for Jenkins slaves.
 build_slaves::distro_packages:

--- a/data/ubuntu/ubuntu_1804.yaml
+++ b/data/ubuntu/ubuntu_1804.yaml
@@ -435,6 +435,7 @@ build_slaves::jenkins::jenkins_packages:
   - asf-build-openjdk14-ea+1
   - asf-build-openjdk14-ea+10
   - asf-build-openjdk15-ea+11
+  - asf-build-openjdk16-ea+24
 
 # Not all build slaves. This is just for Jenkins slaves.
 build_slaves::distro_packages:

--- a/environments/windows/modules/jenkins_node_windows/manifests/init.pp
+++ b/environments/windows/modules/jenkins_node_windows/manifests/init.pp
@@ -100,7 +100,7 @@ class jenkins_node_windows (
     provider => powershell,
   }
   exec { 'create symlink for JDK16':
-    command  => "cmd /c rmdir F:\\jenkins\\tools\\java\\latest16 \"&\" mklink /d F:\\jenkins\\tools\\java\\latest16 F:\\jenkins\\tools\\java\\openjdk16-ea+23",# lint:ignore:140chars
+    command  => "cmd /c rmdir F:\\jenkins\\tools\\java\\latest16 \"&\" mklink /d F:\\jenkins\\tools\\java\\latest16 F:\\jenkins\\tools\\java\\openjdk16-ea+24",# lint:ignore:140chars
     onlyif   => "if ((Get-Item F:\\tools_zips).LastWriteTime -lt (Get-Date).AddMinutes(-60)) { exit 1;}  else { exit 0; }",
     provider => powershell,
   }

--- a/environments/windows/modules/jenkins_node_windows/manifests/params.pp
+++ b/environments/windows/modules/jenkins_node_windows/manifests/params.pp
@@ -10,7 +10,7 @@ class jenkins_node_windows::params (
   $gradle = ['3.5','4.3','4.3.1'],
   $graphviz = ['2.38'],
   $iedriver = ['2.53.1','3.4.0'],
-  $jdk = ['jdk1.5.0_22-32','jdk1.5.0_22-64','jdk1.6.0_30','jdk1.7.0_79-unlimited-security','jdk1.8.0_152','jdk1.8.0_252+b09','jdk9.0','jdk9.0.1','jdk10_46','jdk11-ea+28','jdk12-ea+33','jdk13-ea+30','jdk14-ea+6','jdk15-ea+13','openjdk16-ea+23'], # lint:ignore:140chars
+  $jdk = ['jdk1.5.0_22-32','jdk1.5.0_22-64','jdk1.6.0_30','jdk1.7.0_79-unlimited-security','jdk1.8.0_152','jdk1.8.0_252+b09','jdk9.0','jdk9.0.1','jdk10_46','jdk11-ea+28','jdk12-ea+33','jdk13-ea+30','jdk14-ea+6','jdk15-ea+13','openjdk16-ea+23','openjdk16-ea+24'], # lint:ignore:140chars
   $maven = ['apache-maven-2.0.10','apache-maven-2.0.9','apache-maven-2.2.1','apache-maven-3.0.2','apache-maven-3.0.4','apache-maven-3.0.5','apache-maven-3.1.1','apache-maven-3.2.5','apache-maven-3.3.9','apache-maven-3.5.4','apache-maven-3.6.0','apache-maven-3.6.2','apache-maven-3.6.3'], # lint:ignore:140chars
   $nant = ['0.92'],
   $forrest = ['0.9'],

--- a/modules/build_slaves/manifests/jenkins.pp
+++ b/modules/build_slaves/manifests/jenkins.pp
@@ -145,6 +145,7 @@ class build_slaves::jenkins (
     'openjdk-13-ea+33',
     'openjdk-14-ea+1',
     'openjdk-14-ea+10',
+    'openjdk-16-ea+24',
     ],
 ) {
 
@@ -615,6 +616,10 @@ class build_slaves::jenkins (
   file { "/home/${build_slaves::username}/tools/java/latest14":
     ensure => link,
     target => '/usr/local/asfpackages/java/openjdk-14-ea+10',
+  }
+  file { "/home/${build_slaves::username}/tools/java/latest16":
+    ensure => link,
+    target => '/usr/local/asfpackages/java/openjdk-16-ea+24',
   }
 
   # install all the gradle versions, create symlinks

--- a/modules/buildbot_slave/manifests/buildbot.pp
+++ b/modules/buildbot_slave/manifests/buildbot.pp
@@ -83,6 +83,7 @@ class buildbot_slave::buildbot (
     'openjdk-14-ea+1',
     'openjdk-14-ea+10',
     'openjdk-15-ea+11',
+    'openjdk-16-ea+24',
 ],
   $tools = [
     'ant',
@@ -225,5 +226,9 @@ class buildbot_slave::buildbot (
   file { '/home/buildslave/slave/tools/java/latest15':
     ensure => link,
     target => '/usr/local/asfpackages/java/openjdk-15-ea+11',
+  }
+  file { '/home/buildslave/slave/tools/java/latest16':
+    ensure => link,
+    target => '/usr/local/asfpackages/java/openjdk-16-ea+24',
   }
 }


### PR DESCRIPTION
Add openjdk16-ea+24 to all buildbot and jenkins nodes still using devops/puppet3