### PR TITLE
Directory moved from the CMS to git with usage of the .asf.yaml

### DIFF
--- a/modules/svnwcsub/files/svnwcsub.conf
+++ b/modules/svnwcsub/files/svnwcsub.conf
@@ -62,7 +62,6 @@ LANG: en_US.UTF-8
 /www/deltacloud.apache.org: %(ASF)s/deltacloud/trunk/site/output
 /www/deltaspike.apache.org:  %(CMS)s/deltaspike
 /www/directmemory.apache.org: %(ASF)s/directmemory/site-content
-/www/directory.apache.org: %(CMS)s/directory
 /www/eagle.apache.org: %(ASF)s/eagle/site/
 /www/empire-db.apache.org: %(ASF)s/empire-db/site
 /www/eu12.apachecon.com: %(APACHECON)s/eu12.apachecon.com/


### PR DESCRIPTION
The Directory TLP uses the .asf.yaml now for publishing their website (from the directory-site repo).