### PR TITLE
Allow all disk/repo-local references, lint.

### DIFF
--- a/modules/gitbox/files/asfgit/hooks/ghactions.py
+++ b/modules/gitbox/files/asfgit/hooks/ghactions.py
@@ -28,10 +28,10 @@ ALL_STRINGS = {}
 
 # Allowed GH Actions
 ALLOWED_ACTIONS = [
-    re.compile(r"^\./\.github/.+$"),  # Repo-local action
+    re.compile(r"^\./.+$"),       # Repo-local action
     re.compile(r"^actions/.*$"),  # GitHub Common Actions
-    re.compile(r"^github/.*$"),  # GitHub's own Action collection
-    re.compile(r"^apache/.*$"),  # Apache's action collection
+    re.compile(r"^github/.*$"),   # GitHub's own Action collection
+    re.compile(r"^apache/.*$"),   # Apache's action collection
     re.compile(r"^[-a-z0-9]+/[-A-Za-z0-9]+@([a-f0-9]{7}|[a-f0-9]{40})$"),  # Any commit-pinned action
 ]
 


### PR DESCRIPTION
There seems to be no reason to restrict local actions to the .github directory, and some projects are actively using local references outside that dir, so let's just allow it.