### PR TITLE
INFRA-20525 Add node config for wicket-vm2 (on Ubuntu 20.04)

### DIFF
--- a/data/nodes/wicket-vm2.apache.org.yaml
+++ b/data/nodes/wicket-vm2.apache.org.yaml
@@ -1,0 +1,143 @@
+---
+classes:
+  - wicket_pvm_asf
+  - apache
+  - apache::mod::proxy
+  - apache::mod::proxy_http
+  - apache::mod::proxy_wstunnel
+  - apache::mod::rewrite
+  - vhosts_asf::vhosts
+
+logrotate::rule:
+  apache2:
+    ensure: 'present'
+
+vhosts_asf::vhosts::vhosts:
+  examples7x-80:
+    priority: '12'
+    servername: 'examples7x-test.wicket.apache.org'
+    serveraliases:
+      - 'www.examples7x-test.wicket.apache.org'
+    port: 80
+    ssl: false
+    docroot: '/var/www'
+    error_log_file: 'examples7x_error.log'
+    rewrites:
+      -
+        comment: 'rewrite ssl'
+        rewrite_cond:
+          - "%%{}{HTTPS} !=on"
+        rewrite_rule:
+          - "^/?(.*) https://%%{}{SERVER_NAME}/$1 [R,L]"
+
+  examples7x-443:
+    priority: '12'
+    servername: 'examples7x-test.wicket.apache.org'
+    port: 443
+    ssl: true
+    ssl_cert: '/etc/letsencrypt/live/wicket-vm.apache.org/cert.pem'
+    ssl_key:  '/etc/letsencrypt/live/wicket-vm.apache.org/privkey.pem'
+    ssl_chain: '/etc/letsencrypt/live/wicket-vm.apache.org/chain.pem'
+    docroot: '/var/www'
+    error_log_file: 'examples7x_ssl_error.log'
+    proxy_pass:
+      -
+        path: '/'
+        url: 'http://127.0.0.1:8087/'
+        reverse_urls:
+          - 'http://127.0.0.1:8087/'
+
+  examples8x-80:
+    priority: '12'
+    servername: 'examples8x-test.wicket.apache.org'
+    serveraliases:
+      - 'www.examples8x-test.wicket.apache.org'
+    port: 80
+    ssl: false
+    docroot: '/var/www'
+    error_log_file: 'examples8x_error.log'
+    rewrites:
+      -
+        comment: 'rewrite ssl'
+        rewrite_cond:
+          - "%%{}{HTTPS} !=on"
+        rewrite_rule:
+          - "^/?(.*) https://%%{}{SERVER_NAME}/$1 [R,L]"
+
+  examples8x-443:
+    priority: '12'
+    servername: 'examples8x-test.wicket.apache.org'
+    port: 443
+    ssl: true
+    ssl_cert: '/etc/letsencrypt/live/wicket-vm.apache.org/cert.pem'
+    ssl_key:  '/etc/letsencrypt/live/wicket-vm.apache.org/privkey.pem'
+    ssl_chain: '/etc/letsencrypt/live/wicket-vm.apache.org/chain.pem'
+    docroot: '/var/www'
+    error_log_file: 'examples8x_error.log'
+    proxy_preserve_host: on
+    proxy_pass:
+      -
+        path: '/'
+        url: 'http://127.0.0.1:8088/'
+        reverse_urls:
+          - 'http://127.0.0.1:8088/'
+    rewrites:
+      -
+        comment: 'rewrite websockets'
+        rewrite_cond:
+          - "%%{}{HTTP:UPGRADE} websocket [NC]"
+          - "%%{}{HTTP:CONNECTION} Upgrade$ [NC]"
+        rewrite_rule:
+          - ".* ws://127.0.0.1:8088%%{}{REQUEST_URI} [P]"
+
+  examples9x-80:
+    priority: '12'
+    servername: 'examples9x-test.wicket.apache.org'
+    serveraliases:
+      - 'www.examples9x-test.wicket.apache.org'
+    port: 80
+    ssl: false
+    docroot: '/var/www'
+    error_log_file: 'examples9x_error.log'
+    rewrites:
+      -
+        comment: 'rewrite ssl'
+        rewrite_cond:
+          - "%%{}{HTTPS} !=on"
+        rewrite_rule:
+          - "^/?(.*) https://%%{}{SERVER_NAME}/$1 [R,L]"
+      
+  examples9x-443:
+    priority: '12'
+    servername: 'examples9x-test.wicket.apache.org'
+    port: 443
+    ssl: true
+    ssl_cert: '/etc/letsencrypt/live/wicket-vm.apache.org/cert.pem'
+    ssl_key:  '/etc/letsencrypt/live/wicket-vm.apache.org/privkey.pem'
+    ssl_chain: '/etc/letsencrypt/live/wicket-vm.apache.org/chain.pem'
+    docroot: '/var/www'
+    error_log_file: 'examples9x_ssl_error.log'
+    proxy_preserve_host: on
+    proxy_pass:
+      -
+        path: '/'
+        url: 'http://127.0.0.1:8089/'
+        reverse_urls:
+          - 'http://127.0.0.1:8089/'
+    rewrites:
+      -
+        comment: 'rewrite websockets'
+        rewrite_cond:
+          - "%%{}{HTTP:UPGRADE} websocket [NC]"
+          - "%%{}{HTTP:CONNECTION} Upgrade$ [NC]"
+        rewrite_rule:
+          - ".* ws://127.0.0.1:8088%%{}{REQUEST_URI} [P]"
+
+
+cron:
+  letsencrypt:
+    user: 'root'
+    minute: '0'
+    hour: '0'
+    weekday: '3'
+    command: '/usr/local/bin/certbot-auto renew > /var/log/letsencrypt.log 2>&1'

--- a/modules/wicket_pvm_asf/manifests/init.pp
+++ b/modules/wicket_pvm_asf/manifests/init.pp
@@ -2,7 +2,7 @@
 
 class wicket_pvm_asf (
 
-  $required_packages = ['tomcat8' , 'openjdk-8-jdk', 'docker-engine'],
+  $required_packages = ['tomcat9' , 'openjdk-8-jdk', 'docker-engine'],
 
 ){
 
@@ -13,14 +13,6 @@ class wicket_pvm_asf (
   }
 
 # download wicket docker images from ASF Bintray instance - one for each version for demo.
-# for wicket-6
-  -> exec {
-    'download-wicket-docker-6':
-      command => '/usr/bin/docker pull apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-6',
-      timeout => 1200,
-      require => Package['docker-engine'],
-      notify  => Service['docker-wicket-demo-6'],
-  }
 # for wicket-7
   exec {
     'download-wicket-docker-7':
@@ -46,15 +38,6 @@ class wicket_pvm_asf (
       notify  => Service['docker-wicket-demo-9'],
   }
 
-
-  docker::run { 'wicket-demo-6':
-    image            => 'apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-6',
-    ports            => ['8086:8080'],
-    restart_service  => true,
-    privileged       => false,
-    pull_on_start    => true,
-    extra_parameters => [ '--restart=always' ],
-  }
 
   docker::run { 'wicket-demo-7':
     image            => 'apache-docker-wicket-docker.bintray.io/wicket-examples:LATEST-7',


### PR DESCRIPTION
Drop wicket-6.x Docker image - 6.x is not maintained anymore.
Use Tomcat 9.x instead of 8.x.