### PR TITLE
Fix typo in class name

### DIFF
--- a/modules/gitbox/files/asfgit/git_multimail.py
+++ b/modules/gitbox/files/asfgit/git_multimail.py
@@ -3958,7 +3958,7 @@ def build_environment_klass(env_name):
         low_prec_mixin = known_env['lowprec']
         environment_mixins.append(low_prec_mixin)
     environment_mixins.append(Environment)
-    klass_name = env_name.capitalize() + 'Environement'
+    klass_name = env_name.capitalize() + 'Environment'
     environment_klass = type(
         klass_name,
         tuple(environment_mixins),


### PR DESCRIPTION
This was fixed in the source in 6d19ac2:

The commit says it is unlikely to affect behaviour,
but I wonder if this could relate to
INFRA-21595 - sendmail error during push to gitbox