### PR TITLE
config item values may contain =

### DIFF
--- a/modules/gitbox/files/asfgit/cfg.py
+++ b/modules/gitbox/files/asfgit/cfg.py
@@ -40,7 +40,7 @@ def _repo_name():
 
 if os.environ.get('GIT_ORIGIN_REPO'):
   os.chdir(os.environ.get('GIT_ORIGIN_REPO'))
-_all_config = dict(c.split('=')
+_all_config = dict(c.split('=', 1)
                    for c in run.git('config', '--list')[1].splitlines()
                    if c.strip())
 if os.environ.get('GIT_WIKI_REPO'):


### PR DESCRIPTION
If a config item value contains '=', the code crashes with a message such as

ValueError: dictionary update sequence element #17 has length 3; 2 is required

The fix is to only split once.
