### PR TITLE
Fix environment parameter to SendMailer class

### DIFF
--- a/modules/gitbox/files/hooks/post-receive.d/02-send-emails.py
+++ b/modules/gitbox/files/hooks/post-receive.d/02-send-emails.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
             sys.exit(1)
 
         mailer = git_multimail.SendMailer(
-            os.environ,
+            environment,
             command=['/usr/local/sbin/sendmail', '-oi', '-t'],
             envelopesender='git@apache.org',
             )


### PR DESCRIPTION
The environment parameter is expected to contain a get_logger() attribute.
This is not the case for os.environ.

I think this is what caused the following error message:
remote: Error: _Environ instance has no attribute 'get_logger' 
as reported in:
INFRA-21595 - sendmail error during push to gitbox