### PR TITLE
made the notoc bits work better

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -83,7 +83,8 @@ def custombuild(cfg, yml):
 
     # Get notification list
     pnotify = yml.get('notify', cfg.recips[0])
-
+    # Exclude default table of contents
+    no_toc = yml.get('notoc', False)
     # Contact buildbot 2
     bbusr, bbpwd = open("/x1/gitbox/auth/bb2.txt").read().strip().split(':', 1)
     import requests
@@ -107,6 +108,7 @@ def custombuild(cfg, yml):
                     "buildscript": buildscript,
                     "outputdir": outputdir,
                     "notify": pnotify,
+                    "notoc": no_toc
                 }
             }
     print("Triggering custom build...")
@@ -197,7 +199,10 @@ def pelican(cfg, yml):
     
     # Get notification list
     pnotify = yml.get('notify', cfg.recips[0])
-    
+
+    # Get TOC boolean
+    no_toc = yml.get('notoc', False)
+
     # Contact buildbot 2
     bbusr, bbpwd = open("/x1/gitbox/auth/bb2.txt").read().strip().split(':', 1)
     import requests
@@ -217,6 +222,7 @@ def pelican(cfg, yml):
             "project": pname,
             "theme": theme,
             "notify": pnotify,
+            "notoc": no_toc,
         }
     }
     print("Triggering pelican build...")


### PR DESCRIPTION
Adding a `notoc` argument for pelican.

`notoc` defaults to `False` so no changes should be needed for everything to work exactly as it already does.
If we want to exclude the default Table of Contents plugin all that should be necessary is to add:
`notoc: True` to .asf.yaml under the pelican section.