### PR TITLE
add autobuild to pelican, add autostage to staging

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -189,7 +189,7 @@ def pelican(cfg, yml):
     autobuild = yml.get('autobuild')
     if autobuild:
         assert autobuild.endswith('/*'), "autobuild parameter must be $foo/*, e.g. site/* or feature/*"
-    do_autobuild = autobuild and fnmatch.fnmatch(ref, autobuild)
+    do_autobuild = autobuild and fnmatch.fnmatch(ref, autobuild) and not ref.endswith('-staging')  # don't autobuild the autobuilt
     if whoami and whoami != ref and not do_autobuild:
         return
     


### PR DESCRIPTION
autobuild will automatically site-build any pelican branch matching the autobuild target glob, for example site/*. The output will be in $branch-staging, e.g. site/foo-staging.
autostage will automatically stage any matching branch ending in '-staging'. For instance, site/* will stage site/foo-staging as $project-foo.staged.a.o, whereas it would not stage site/foo (as that is considered a source branch).