### PR TITLE
Do the cheapest checks first

### DIFF
--- a/modules/gitbox/files/asfgit/asfyaml.py
+++ b/modules/gitbox/files/asfgit/asfyaml.py
@@ -715,12 +715,11 @@ def notifications(cfg, yml):
             raise Exception("Invalid notification scheme '%s' detected, please remove it!" % k)
         # Verify that all set schemes pass muster and point to $foo@$project.a.o
         if k != 'jira_options':
-            if not RE_VALID_MAILINGLIST.match(v)\
-                or not (
+            if not (
                     v.endswith('@apache.org') or
                     v.endswith('@%s.apache.org' % pname) or
                     v.endswith('@%s.incubator.apache.org' % pname)
-                ) or v not in valid_lists:
+            ) or v not in valid_lists or not RE_VALID_MAILINGLIST.match(v):
                 raise Exception("Invalid notification target '%s'. Must be a valid @%s.apache.org list!" % (v, pname))
 
     # All seems kosher, update settings if need be


### PR DESCRIPTION
Note: the RE check is likely to be superfluous if done last, as errors should be caught by the check against valid_lists.

If the RE check does fail, it is possible that the RE is too strict, otherwise why would the list be in valid_lists?